### PR TITLE
Feature/#2 entity mapping/kan 93

### DIFF
--- a/blog-service/build.gradle
+++ b/blog-service/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/BaseEntity.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/BaseEntity.java
@@ -1,0 +1,27 @@
+package myaong.popolog.blogservice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+	// 등록일
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	// 수정일
+	@LastModifiedDate
+	@Column(name = "created_at")
+	private LocalDateTime updatedAt;
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/BaseEntity.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/BaseEntity.java
@@ -22,6 +22,6 @@ public abstract class BaseEntity {
 
 	// 수정일
 	@LastModifiedDate
-	@Column(name = "created_at")
+	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 }

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/Bookmark.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/Bookmark.java
@@ -1,0 +1,27 @@
+package myaong.popolog.blogservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`bookmark`",
+		uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "post_id"})})
+@Getter
+@Setter
+public class Bookmark extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "bookmark_id", columnDefinition = "int unsigned")
+	private Long id;
+
+	// 북마크한 회원 => 회원 정보 자체를 쓸 일은 없음(중복만 확인)
+	@Column(name = "member_id", columnDefinition = "int unsigned")
+	private Long memberId;
+
+	// 대상 포스트
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "post_id")
+	private Post post;
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/Bookmark.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/Bookmark.java
@@ -13,11 +13,11 @@ public class Bookmark extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "bookmark_id", columnDefinition = "int unsigned")
+	@Column(name = "bookmark_id")
 	private Long id;
 
 	// 북마크한 회원 => 회원 정보 자체를 쓸 일은 없음(중복만 확인)
-	@Column(name = "member_id", columnDefinition = "int unsigned")
+	@Column(name = "member_id")
 	private Long memberId;
 
 	// 대상 포스트

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/Bookmark.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/Bookmark.java
@@ -1,14 +1,16 @@
 package myaong.popolog.blogservice.domain;
 
+
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`bookmark`",
 		uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "post_id"})})
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Bookmark extends BaseEntity {
 
 	@Id
@@ -17,11 +19,11 @@ public class Bookmark extends BaseEntity {
 	private Long id;
 
 	// 북마크한 회원 => 회원 정보 자체를 쓸 일은 없음(중복만 확인)
-	@Column(name = "member_id")
+	@Column(name = "member_id", updatable = false)
 	private Long memberId;
 
 	// 대상 포스트
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "post_id")
+	@JoinColumn(name = "post_id", updatable = false)
 	private Post post;
 }

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/Comment.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/Comment.java
@@ -1,13 +1,14 @@
 package myaong.popolog.blogservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`comment`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseEntity {
 
 	@Id
@@ -17,17 +18,17 @@ public class Comment extends BaseEntity {
 
 	// 본 댓글이 달린 포스트
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "post_id", nullable = false)
+	@JoinColumn(name = "post_id", nullable = false, updatable = false)
 	private Post post;
 
 	// 댓글 작성자. 작성자 탈퇴 시 null
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id")
+	@JoinColumn(name = "member_id", updatable = false)
 	private MemberProfile memberProfile;
 
 	// 답글인 경우, 본 답글이 달린 댓글. 댓글인 경우 null
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "parent_comment_id")
+	@JoinColumn(name = "parent_comment_id", updatable = false)
 	private Comment parentComment;
 
 	@Lob
@@ -36,4 +37,9 @@ public class Comment extends BaseEntity {
 
 	@Column(name = "is_blinded")
 	private Boolean isBlinded;
+
+	public Comment(String content, Boolean isBlinded) {
+		this.content = content;
+		this.isBlinded = isBlinded;
+	}
 }

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/Comment.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/Comment.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class Comment extends BaseEntity {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "comment_id")

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/Comment.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/Comment.java
@@ -33,4 +33,7 @@ public class Comment extends BaseEntity {
 	@Lob
 	@Column(name = "content", nullable = false)
 	private String content;
+
+	@Column(name = "is_blinded")
+	private Boolean isBlinded;
 }

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/Comment.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/Comment.java
@@ -1,0 +1,35 @@
+package myaong.popolog.blogservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`comment`")
+@Getter
+@Setter
+public class Comment extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "comment_id")
+	private Long id;
+
+	// 본 댓글이 달린 포스트
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "post_id", nullable = false)
+	private Post post;
+
+	// 댓글 작성자. 작성자 탈퇴 시 null
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private MemberProfile memberProfile;
+
+	// 답글인 경우, 본 답글이 달린 댓글. 댓글인 경우 null
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "parent_comment_id")
+	private Comment parentComment;
+
+	@Lob
+	@Column(name = "content", nullable = false)
+	private String content;
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/Like.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/Like.java
@@ -1,14 +1,15 @@
 package myaong.popolog.blogservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`like`",
 		uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "post_id"})})
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Like extends BaseEntity {
 
 	@Id
@@ -17,11 +18,11 @@ public class Like extends BaseEntity {
 	private Long id;
 
 	// 좋아요를 남긴 회원
-	@Column(name = "member_id", nullable = false)
+	@Column(name = "member_id", nullable = false, updatable = false)
 	private Long memberId;
 
 	// 대상 포스트
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "post_id", nullable = false)
+	@JoinColumn(name = "post_id", nullable = false, updatable = false)
 	private Post post;
 }

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/Like.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/Like.java
@@ -1,0 +1,27 @@
+package myaong.popolog.blogservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`like`",
+		uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "post_id"})})
+@Getter
+@Setter
+public class Like extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "like_id")
+	private Long id;
+
+	// 좋아요를 남긴 회원
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	// 대상 포스트
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "post_id", nullable = false)
+	private Post post;
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/MemberProfile.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/MemberProfile.java
@@ -1,0 +1,24 @@
+package myaong.popolog.blogservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`member_profile`")
+@Getter
+@Setter
+public class MemberProfile extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_id")
+	private Long id;
+
+	@Column(name = "nickname", nullable = false)
+	private String nickname;
+
+	// 프로필 사진 주소
+	@Column(name = "profile_pic_url")
+	private String profilePicUrl;
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/MemberProfile.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/MemberProfile.java
@@ -1,13 +1,15 @@
 package myaong.popolog.blogservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`member_profile`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberProfile extends BaseEntity {
 
 	@Id
@@ -21,4 +23,10 @@ public class MemberProfile extends BaseEntity {
 	// 프로필 사진 주소
 	@Column(name = "profile_pic_url")
 	private String profilePicUrl;
+
+	@Builder
+	public MemberProfile(String nickname, String profilePicUrl) {
+		this.nickname = nickname;
+		this.profilePicUrl = profilePicUrl;
+	}
 }

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/Post.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/Post.java
@@ -30,4 +30,7 @@ public class Post extends BaseEntity {
 	// 섬네일 주소
 	@Column(name = "thumbnail_url")
 	private String thumbnailUrl;
+
+	@Column(name = "is_blinded")
+	private Boolean isBlinded;
 }

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/Post.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/Post.java
@@ -1,0 +1,33 @@
+package myaong.popolog.blogservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`post`")
+@Getter
+@Setter
+public class Post extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "post_id")
+	private Long id;
+
+	// 작성자 정보
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private MemberProfile memberProfile;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Lob
+	@Column(name = "content", nullable = false)
+	private String content;
+
+	// 섬네일 주소
+	@Column(name = "thumbnail_url")
+	private String thumbnailUrl;
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/Post.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/Post.java
@@ -1,13 +1,15 @@
 package myaong.popolog.blogservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`post`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseEntity {
 
 	@Id
@@ -33,4 +35,12 @@ public class Post extends BaseEntity {
 
 	@Column(name = "is_blinded")
 	private Boolean isBlinded;
+
+	@Builder
+	public Post(String title, String content, String thumbnailUrl, Boolean isBlinded) {
+		this.title = title;
+		this.content = content;
+		this.thumbnailUrl = thumbnailUrl;
+		this.isBlinded = isBlinded;
+	}
 }

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/Report.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/Report.java
@@ -1,0 +1,32 @@
+package myaong.popolog.blogservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import myaong.popolog.blogservice.enums.ContentsType;
+
+@Entity
+@Table(name = "`report`",
+		uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "contents_id", "contents_type"})})
+@Getter
+@Setter
+public class Report extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "report_id")
+	private Long id;
+
+	// 신고한 회원
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	// 대상 콘텐츠
+	@Column(name = "contents_id", nullable = false)
+	private Long contentsId;
+
+	// 콘텐츠 타입
+	@Enumerated(EnumType.STRING)
+	@Column(name = "contents_type", nullable = false)
+	private ContentsType contentsType;
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/domain/Report.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/domain/Report.java
@@ -1,15 +1,16 @@
 package myaong.popolog.blogservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import myaong.popolog.blogservice.enums.ContentsType;
 
 @Entity
 @Table(name = "`report`",
 		uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "contents_id", "contents_type"})})
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Report extends BaseEntity {
 
 	@Id

--- a/blog-service/src/main/java/myaong/popolog/blogservice/enums/ContentsType.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/enums/ContentsType.java
@@ -1,0 +1,10 @@
+package myaong.popolog.blogservice.enums;
+
+public enum ContentsType {
+
+	POST, COMMENT;
+
+	public static ContentsType valueOfLower(String name) {
+		return ContentsType.valueOf(name.toUpperCase());
+	}
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/repository/BookmarkRepository.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/repository/BookmarkRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.blogservice.repository;
+
+import myaong.popolog.blogservice.domain.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/repository/CommentRepository.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.blogservice.repository;
+
+import myaong.popolog.blogservice.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/repository/LikeRepository.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/repository/LikeRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.blogservice.repository;
+
+import myaong.popolog.blogservice.domain.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/repository/MemberProfileRepository.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/repository/MemberProfileRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.blogservice.repository;
+
+import myaong.popolog.blogservice.domain.MemberProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberProfileRepository extends JpaRepository<MemberProfile, Long> {
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/repository/PostRepository.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.blogservice.repository;
+
+import myaong.popolog.blogservice.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/repository/ReportRepository.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/repository/ReportRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.blogservice.repository;
+
+import myaong.popolog.blogservice.domain.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/blog-service/src/main/resources/application-local.yml
+++ b/blog-service/src/main/resources/application-local.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/test
+    driver-class-name: org.h2.Driver
+    username: sa
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true

--- a/blog-service/src/main/resources/application.yml
+++ b/blog-service/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: blog-service
+  profiles:
+    active: local
 
 eureka:
   instance:

--- a/inquiry-service/build.gradle
+++ b/inquiry-service/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/BaseEntity.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/BaseEntity.java
@@ -22,6 +22,6 @@ public abstract class BaseEntity {
 
 	// 수정일
 	@LastModifiedDate
-	@Column(name = "created_at")
+	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 }

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/BaseEntity.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/BaseEntity.java
@@ -1,0 +1,27 @@
+package myaong.popolog.inquiryservice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+	// 등록일
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	// 수정일
+	@LastModifiedDate
+	@Column(name = "created_at")
+	private LocalDateTime updatedAt;
+}

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/Inquiry.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/Inquiry.java
@@ -1,13 +1,14 @@
 package myaong.popolog.inquiryservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`inquiry`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Inquiry extends BaseEntity {
 
 	@Id

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/Inquiry.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/Inquiry.java
@@ -28,5 +28,5 @@ public class Inquiry extends BaseEntity {
 
 	// 비밀글 여부
 	@Column(name = "is_secret", nullable = false)
-	private Boolean istSecret;
+	private Boolean isSecret;
 }

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/Inquiry.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/Inquiry.java
@@ -1,0 +1,32 @@
+package myaong.popolog.inquiryservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`inquiry`")
+@Getter
+@Setter
+public class Inquiry extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "inquiry_id")
+	private Long id;
+
+	// 문의 작성자
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Lob
+	@Column(name = "content", nullable = false)
+	private String content;
+
+	// 비밀글 여부
+	@Column(name = "is_secret", nullable = false)
+	private Boolean istSecret;
+}

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/InquiryAuthor.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/InquiryAuthor.java
@@ -5,10 +5,10 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Entity
-@Table(name = "`member_profile`")
+@Table(name = "`inquiry_author`")
 @Getter
 @Setter
-public class MemberProfile extends BaseEntity {
+public class InquiryAuthor extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/InquiryAuthor.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/InquiryAuthor.java
@@ -1,13 +1,14 @@
 package myaong.popolog.inquiryservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`inquiry_author`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InquiryAuthor extends BaseEntity {
 
 	@Id

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/InquiryReply.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/InquiryReply.java
@@ -1,13 +1,14 @@
 package myaong.popolog.inquiryservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`inquiry_reply`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InquiryReply extends BaseEntity {
 
 	@Id
@@ -17,14 +18,14 @@ public class InquiryReply extends BaseEntity {
 
 	// 부모 문의
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "inquiry_id", nullable = false, unique = true)
+	@JoinColumn(name = "inquiry_id", nullable = false, unique = true, updatable = false)
 	private Inquiry inquiry;
 
 	// 문의 답변자
-	@Column(name = "member_id", nullable = false)
+	@Column(name = "member_id", nullable = false, updatable = false)
 	private Long memberId;
 
 	@Lob
-	@Column(name = "content", nullable = false)
+	@Column(name = "content", nullable = false, updatable = false)
 	private String content;
 }

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/InquiryReply.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/InquiryReply.java
@@ -1,0 +1,30 @@
+package myaong.popolog.inquiryservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`inquiry_reply`")
+@Getter
+@Setter
+public class InquiryReply extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "inquiry_reply_id")
+	private Long id;
+
+	// 부모 문의
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "inquiry_id", nullable = false, unique = true)
+	private Inquiry inquiry;
+
+	// 문의 답변자
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	@Lob
+	@Column(name = "content", nullable = false)
+	private String content;
+}

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/MemberProfile.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/domain/MemberProfile.java
@@ -1,0 +1,21 @@
+package myaong.popolog.inquiryservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`member_profile`")
+@Getter
+@Setter
+public class MemberProfile extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_id")
+	private Long id;
+
+	// 글 조회 시 로그인 아이디 표시
+	@Column(name = "username", nullable = false)
+	private String username;
+}

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/repository/InquiryAuthorRepository.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/repository/InquiryAuthorRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.inquiryservice.repository;
+
+import myaong.popolog.inquiryservice.domain.InquiryAuthor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InquiryAuthorRepository extends JpaRepository<InquiryAuthor, Long> {
+}

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/repository/InquiryReplyRepository.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/repository/InquiryReplyRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.inquiryservice.repository;
+
+import myaong.popolog.inquiryservice.domain.InquiryReply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InquiryReplyRepository extends JpaRepository<InquiryReply, Long> {
+}

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/repository/InquiryRepository.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/repository/InquiryRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.inquiryservice.repository;
+
+import myaong.popolog.inquiryservice.domain.Inquiry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+}

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/repository/MemberProfileRepository.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/repository/MemberProfileRepository.java
@@ -1,7 +1,0 @@
-package myaong.popolog.inquiryservice.repository;
-
-import myaong.popolog.inquiryservice.domain.MemberProfile;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface MemberProfileRepository extends JpaRepository<MemberProfile, Long> {
-}

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/repository/MemberProfileRepository.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/repository/MemberProfileRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.inquiryservice.repository;
+
+import myaong.popolog.inquiryservice.domain.MemberProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberProfileRepository extends JpaRepository<MemberProfile, Long> {
+}

--- a/inquiry-service/src/main/resources/application-local.yml
+++ b/inquiry-service/src/main/resources/application-local.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/test
+    driver-class-name: org.h2.Driver
+    username: sa
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true

--- a/inquiry-service/src/main/resources/application.yml
+++ b/inquiry-service/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: inquiry-service
+  profiles:
+    active: local
 
 eureka:
   instance:

--- a/interview-service/build.gradle
+++ b/interview-service/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/domain/BaseEntity.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/domain/BaseEntity.java
@@ -1,0 +1,27 @@
+package myaong.popolog.interviewservice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+	// 등록일
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	// 수정일
+	@LastModifiedDate
+	@Column(name = "created_at")
+	private LocalDateTime updatedAt;
+}

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/domain/BaseEntity.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/domain/BaseEntity.java
@@ -22,6 +22,6 @@ public abstract class BaseEntity {
 
 	// 수정일
 	@LastModifiedDate
-	@Column(name = "created_at")
+	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 }

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Company.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Company.java
@@ -1,13 +1,15 @@
 package myaong.popolog.interviewservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`company`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Company extends BaseEntity {
 
 	@Id
@@ -17,4 +19,9 @@ public class Company extends BaseEntity {
 
 	@Column(name = "company_name", nullable = false, unique = true)
 	private String name;
+
+	@Builder
+	public Company(String name) {
+		this.name = name;
+	}
 }

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Company.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Company.java
@@ -15,6 +15,6 @@ public class Company extends BaseEntity {
 	@Column(name = "company_id")
 	private Long id;
 
-	@Column(name = "company_name", nullable = false)
+	@Column(name = "company_name", nullable = false, unique = true)
 	private String name;
 }

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Company.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Company.java
@@ -1,0 +1,20 @@
+package myaong.popolog.interviewservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`company`")
+@Getter
+@Setter
+public class Company extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "company_id")
+	private Long id;
+
+	@Column(name = "company_name", nullable = false)
+	private String name;
+}

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Interview.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Interview.java
@@ -1,0 +1,26 @@
+package myaong.popolog.interviewservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`interview`")
+@Getter
+@Setter
+public class Interview extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "interview_id")
+	private Long id;
+
+	// 생성한 회원
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	// 대상 기업
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "company_id", nullable = false)
+	private Company company;
+}

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Interview.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Interview.java
@@ -1,13 +1,14 @@
 package myaong.popolog.interviewservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`interview`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Interview extends BaseEntity {
 
 	@Id
@@ -16,11 +17,11 @@ public class Interview extends BaseEntity {
 	private Long id;
 
 	// 생성한 회원
-	@Column(name = "member_id", nullable = false)
+	@Column(name = "member_id", nullable = false, updatable = false)
 	private Long memberId;
 
 	// 대상 기업
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "company_id", nullable = false)
+	@JoinColumn(name = "company_id", nullable = false, updatable = false)
 	private Company company;
 }

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/domain/InterviewRole.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/domain/InterviewRole.java
@@ -1,0 +1,10 @@
+package myaong.popolog.interviewservice.domain;
+
+public enum InterviewRole {
+
+	INTERVIEWER, INTERVIEWEE;
+
+	public static InterviewRole valueOfLower(String name) {
+		return InterviewRole.valueOf(name.toUpperCase());
+	}
+}

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Message.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Message.java
@@ -1,14 +1,16 @@
 package myaong.popolog.interviewservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import myaong.popolog.interviewservice.enums.InterviewRole;
 
 @Entity
 @Table(name = "`message`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Message extends BaseEntity {
 
 	@Id
@@ -18,15 +20,20 @@ public class Message extends BaseEntity {
 
 	// 대상 면접
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "interview_id", nullable = false)
+	@JoinColumn(name = "interview_id", nullable = false, updatable = false)
 	private Interview interview;
 
 	// 메시지 역할
 	@Enumerated(EnumType.STRING)
-	@Column(name = "interview_role", nullable = false)
+	@Column(name = "interview_role", nullable = false, updatable = false)
 	private InterviewRole role;
 
 	@Lob
 	@Column(name = "content", nullable = false)
 	private String content;
+
+	@Builder
+	public Message(String content) {
+		this.content = content;
+	}
 }

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Message.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Message.java
@@ -3,6 +3,7 @@ package myaong.popolog.interviewservice.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import myaong.popolog.interviewservice.enums.InterviewRole;
 
 @Entity
 @Table(name = "`message`")

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Message.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/domain/Message.java
@@ -1,0 +1,31 @@
+package myaong.popolog.interviewservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`message`")
+@Getter
+@Setter
+public class Message extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "message_id")
+	private Long id;
+
+	// 대상 면접
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "interview_id", nullable = false)
+	private Interview interview;
+
+	// 메시지 역할
+	@Enumerated(EnumType.STRING)
+	@Column(name = "interview_role", nullable = false)
+	private InterviewRole role;
+
+	@Lob
+	@Column(name = "content", nullable = false)
+	private String content;
+}

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/enums/InterviewRole.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/enums/InterviewRole.java
@@ -1,4 +1,4 @@
-package myaong.popolog.interviewservice.domain;
+package myaong.popolog.interviewservice.enums;
 
 public enum InterviewRole {
 

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/repository/CompanyRepository.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/repository/CompanyRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.interviewservice.repository;
+
+import myaong.popolog.interviewservice.domain.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompanyRepository extends JpaRepository<Company, Long> {
+}

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/repository/InterviewRepository.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/repository/InterviewRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.interviewservice.repository;
+
+import myaong.popolog.interviewservice.domain.Interview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewRepository extends JpaRepository<Interview, Long> {
+}

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/repository/InterviewRoleRepository.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/repository/InterviewRoleRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.interviewservice.repository;
+
+import myaong.popolog.interviewservice.domain.InterviewRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewRoleRepository extends JpaRepository<InterviewRole, Long> {
+}

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/repository/InterviewRoleRepository.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/repository/InterviewRoleRepository.java
@@ -1,7 +1,0 @@
-package myaong.popolog.interviewservice.repository;
-
-import myaong.popolog.interviewservice.domain.InterviewRole;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface InterviewRoleRepository extends JpaRepository<InterviewRole, Long> {
-}

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/repository/MessageRepository.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/repository/MessageRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.interviewservice.repository;
+
+import myaong.popolog.interviewservice.domain.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+}

--- a/interview-service/src/main/resources/application-local.yml
+++ b/interview-service/src/main/resources/application-local.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/test
+    driver-class-name: org.h2.Driver
+    username: sa
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true

--- a/interview-service/src/main/resources/application.yml
+++ b/interview-service/src/main/resources/application.yml
@@ -4,6 +4,8 @@ server:
 spring:
   application:
     name: interview-service
+  profiles:
+    active: local
 
 eureka:
   client:

--- a/member-service/build.gradle
+++ b/member-service/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
 //    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/member-service/src/main/java/myaong/popolog/memberservice/domain/BaseEntity.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/domain/BaseEntity.java
@@ -1,0 +1,27 @@
+package myaong.popolog.memberservice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+	// 등록일
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	// 수정일
+	@LastModifiedDate
+	@Column(name = "created_at")
+	private LocalDateTime updatedAt;
+}

--- a/member-service/src/main/java/myaong/popolog/memberservice/domain/BaseEntity.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/domain/BaseEntity.java
@@ -22,6 +22,6 @@ public abstract class BaseEntity {
 
 	// 수정일
 	@LastModifiedDate
-	@Column(name = "created_at")
+	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 }

--- a/member-service/src/main/java/myaong/popolog/memberservice/domain/Follow.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/domain/Follow.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Entity
-@Table(name = "`follow`")
+@Table(name = "`follow`",
+		uniqueConstraints = {@UniqueConstraint(columnNames = {"following", "followed"})})
 @Getter
 @Setter
 public class Follow extends BaseEntity {

--- a/member-service/src/main/java/myaong/popolog/memberservice/domain/Follow.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/domain/Follow.java
@@ -1,14 +1,15 @@
 package myaong.popolog.memberservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`follow`",
 		uniqueConstraints = {@UniqueConstraint(columnNames = {"following", "followed"})})
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Follow extends BaseEntity {
 
 	@Id
@@ -18,11 +19,11 @@ public class Follow extends BaseEntity {
 
 	// 팔로우하는 사람
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "following", nullable = false)
+	@JoinColumn(name = "following", nullable = false, updatable = false)
 	private Member following;
 
 	// 팔로우된 사람
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "followed", nullable = false)
+	@JoinColumn(name = "followed", nullable = false, updatable = false)
 	private Member followed;
 }

--- a/member-service/src/main/java/myaong/popolog/memberservice/domain/Follow.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/domain/Follow.java
@@ -1,0 +1,27 @@
+package myaong.popolog.memberservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`follow`")
+@Getter
+@Setter
+public class Follow extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "follow_id")
+	private Long id;
+
+	// 팔로우하는 사람
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "following", nullable = false)
+	private Member following;
+
+	// 팔로우된 사람
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "followed", nullable = false)
+	private Member followed;
+}

--- a/member-service/src/main/java/myaong/popolog/memberservice/domain/Member.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/domain/Member.java
@@ -3,6 +3,8 @@ package myaong.popolog.memberservice.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import myaong.popolog.memberservice.enums.Permission;
+import myaong.popolog.memberservice.enums.SocialType;
 
 import java.time.LocalDate;
 

--- a/member-service/src/main/java/myaong/popolog/memberservice/domain/Member.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/domain/Member.java
@@ -1,0 +1,59 @@
+package myaong.popolog.memberservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "`member`")
+@Getter
+@Setter
+public class Member extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_id")
+	private Long id;
+
+	// 로그인 아이디
+	@Column(name = "username", nullable = false, unique = true)
+	private String username;
+
+	@Column(name = "password")
+	private String password;
+
+	// 소셜 로그인 타입
+	@Enumerated(EnumType.STRING)
+	@Column(name = "social_type", nullable = false)
+	private SocialType socialType;
+
+	// 본명
+	@Column(name = "name", nullable = false)
+	private String name;
+
+	// 닉네임
+	@Column(name = "nickname", nullable = false)
+	private String nickname;
+
+	@Column(name = "email", nullable = false, unique = true)
+	private String email;
+
+	// 권한
+	@Enumerated(EnumType.STRING)
+	@Column(name = "permission", nullable = false)
+	private Permission permission;
+
+	// 프로필 사진 주소
+	@Column(name = "profile_pic_url")
+	private String profilePicUrl;
+
+	// 로그인 시도 횟수. 로그인 성공 시 초기
+	@Column(name = "count_attempt", nullable = false)
+	private Integer countAttempt;
+
+	// 정지 해제일. (오늘 날짜 < 정지 해제일)이면 정지된 회원
+	@Column(name = "unban_date", nullable = false)
+	private LocalDate unbanDate;
+}

--- a/member-service/src/main/java/myaong/popolog/memberservice/domain/Member.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/domain/Member.java
@@ -1,8 +1,10 @@
 package myaong.popolog.memberservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import myaong.popolog.memberservice.enums.Permission;
 import myaong.popolog.memberservice.enums.SocialType;
 
@@ -11,7 +13,7 @@ import java.time.LocalDate;
 @Entity
 @Table(name = "`member`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
 	@Id
@@ -20,7 +22,7 @@ public class Member extends BaseEntity {
 	private Long id;
 
 	// 로그인 아이디
-	@Column(name = "username", nullable = false, unique = true)
+	@Column(name = "username", nullable = false, unique = true, updatable = false)
 	private String username;
 
 	@Column(name = "password")
@@ -28,7 +30,7 @@ public class Member extends BaseEntity {
 
 	// 소셜 로그인 타입
 	@Enumerated(EnumType.STRING)
-	@Column(name = "social_type", nullable = false)
+	@Column(name = "social_type", nullable = false, updatable = false)
 	private SocialType socialType;
 
 	// 본명
@@ -58,4 +60,16 @@ public class Member extends BaseEntity {
 	// 정지 해제일. (오늘 날짜 < 정지 해제일)이면 정지된 회원
 	@Column(name = "unban_date", nullable = false)
 	private LocalDate unbanDate;
+
+	@Builder
+	public Member(String password, String name, String nickname, String email, Permission permission, String profilePicUrl, Integer countAttempt, LocalDate unbanDate) {
+		this.password = password;
+		this.name = name;
+		this.nickname = nickname;
+		this.email = email;
+		this.permission = permission;
+		this.profilePicUrl = profilePicUrl;
+		this.countAttempt = countAttempt;
+		this.unbanDate = unbanDate;
+	}
 }

--- a/member-service/src/main/java/myaong/popolog/memberservice/domain/Permission.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/domain/Permission.java
@@ -1,0 +1,10 @@
+package myaong.popolog.memberservice.domain;
+
+public enum Permission {
+
+	MEMBER, ADMIN, SUPER;
+
+	public static Permission valueOfLower(String name) {
+		return Permission.valueOf(name.toUpperCase());
+	}
+}

--- a/member-service/src/main/java/myaong/popolog/memberservice/domain/SocialType.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/domain/SocialType.java
@@ -1,0 +1,10 @@
+package myaong.popolog.memberservice.domain;
+
+public enum SocialType {
+
+	NORMAL, KAKAO, GOOGLE;
+
+	public static SocialType valueOfLower(String name) {
+		return SocialType.valueOf(name.toUpperCase());
+	}
+}

--- a/member-service/src/main/java/myaong/popolog/memberservice/enums/Permission.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/enums/Permission.java
@@ -1,4 +1,4 @@
-package myaong.popolog.memberservice.domain;
+package myaong.popolog.memberservice.enums;
 
 public enum Permission {
 

--- a/member-service/src/main/java/myaong/popolog/memberservice/enums/SocialType.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/enums/SocialType.java
@@ -1,4 +1,4 @@
-package myaong.popolog.memberservice.domain;
+package myaong.popolog.memberservice.enums;
 
 public enum SocialType {
 

--- a/member-service/src/main/java/myaong/popolog/memberservice/repository/FollowRepository.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/repository/FollowRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.memberservice.repository;
+
+import myaong.popolog.memberservice.domain.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+}

--- a/member-service/src/main/java/myaong/popolog/memberservice/repository/MemberRepository.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.memberservice.repository;
+
+import myaong.popolog.memberservice.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/member-service/src/main/java/myaong/popolog/memberservice/repository/PermissionRepository.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/repository/PermissionRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.memberservice.repository;
+
+import myaong.popolog.memberservice.domain.Permission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PermissionRepository extends JpaRepository<Permission, Long> {
+}

--- a/member-service/src/main/java/myaong/popolog/memberservice/repository/PermissionRepository.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/repository/PermissionRepository.java
@@ -1,7 +1,0 @@
-package myaong.popolog.memberservice.repository;
-
-import myaong.popolog.memberservice.domain.Permission;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PermissionRepository extends JpaRepository<Permission, Long> {
-}

--- a/member-service/src/main/java/myaong/popolog/memberservice/repository/SocialTypeRepository.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/repository/SocialTypeRepository.java
@@ -1,7 +1,0 @@
-package myaong.popolog.memberservice.repository;
-
-import myaong.popolog.memberservice.domain.SocialType;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface SocialTypeRepository extends JpaRepository<SocialType, Long> {
-}

--- a/member-service/src/main/java/myaong/popolog/memberservice/repository/SocialTypeRepository.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/repository/SocialTypeRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.memberservice.repository;
+
+import myaong.popolog.memberservice.domain.SocialType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SocialTypeRepository extends JpaRepository<SocialType, Long> {
+}

--- a/member-service/src/main/resources/application-local.yml
+++ b/member-service/src/main/resources/application-local.yml
@@ -1,0 +1,13 @@
+
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/test
+    driver-class-name: org.h2.Driver
+    username: sa
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true

--- a/member-service/src/main/resources/application.yml
+++ b/member-service/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: member-service
+  profiles:
+    active: local
 
 eureka:
   instance:

--- a/notice-service/build.gradle
+++ b/notice-service/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/notice-service/src/main/java/myaong/popolog/noticeservice/domain/BaseEntity.java
+++ b/notice-service/src/main/java/myaong/popolog/noticeservice/domain/BaseEntity.java
@@ -1,0 +1,27 @@
+package myaong.popolog.noticeservice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+	// 등록일
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	// 수정일
+	@LastModifiedDate
+	@Column(name = "created_at")
+	private LocalDateTime updatedAt;
+}

--- a/notice-service/src/main/java/myaong/popolog/noticeservice/domain/BaseEntity.java
+++ b/notice-service/src/main/java/myaong/popolog/noticeservice/domain/BaseEntity.java
@@ -22,6 +22,6 @@ public abstract class BaseEntity {
 
 	// 수정일
 	@LastModifiedDate
-	@Column(name = "created_at")
+	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 }

--- a/notice-service/src/main/java/myaong/popolog/noticeservice/domain/Notice.java
+++ b/notice-service/src/main/java/myaong/popolog/noticeservice/domain/Notice.java
@@ -22,6 +22,6 @@ public class Notice extends BaseEntity {
 	private String content;
 
 	// 중요 여부
-	@Column(name = "is_secret", nullable = false)
-	private Boolean istSecret;
+	@Column(name = "is_important", nullable = false)
+	private Boolean isImportant;
 }

--- a/notice-service/src/main/java/myaong/popolog/noticeservice/domain/Notice.java
+++ b/notice-service/src/main/java/myaong/popolog/noticeservice/domain/Notice.java
@@ -1,0 +1,27 @@
+package myaong.popolog.noticeservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`notice`")
+@Getter
+@Setter
+public class Notice extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notice_id")
+	private Long id;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Column(name = "content", nullable = false)
+	private String content;
+
+	// 중요 여부
+	@Column(name = "is_secret", nullable = false)
+	private Boolean istSecret;
+}

--- a/notice-service/src/main/java/myaong/popolog/noticeservice/domain/Notice.java
+++ b/notice-service/src/main/java/myaong/popolog/noticeservice/domain/Notice.java
@@ -1,13 +1,15 @@
 package myaong.popolog.noticeservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`notice`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notice extends BaseEntity {
 
 	@Id
@@ -24,4 +26,11 @@ public class Notice extends BaseEntity {
 	// 중요 여부
 	@Column(name = "is_important", nullable = false)
 	private Boolean isImportant;
+
+	@Builder
+	public Notice(String title, String content, Boolean isImportant) {
+		this.title = title;
+		this.content = content;
+		this.isImportant = isImportant;
+	}
 }

--- a/notice-service/src/main/java/myaong/popolog/noticeservice/repository/NoticeRepository.java
+++ b/notice-service/src/main/java/myaong/popolog/noticeservice/repository/NoticeRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.noticeservice.repository;
+
+import myaong.popolog.noticeservice.domain.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+}

--- a/notice-service/src/main/resources/application-local.yml
+++ b/notice-service/src/main/resources/application-local.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/test
+    driver-class-name: org.h2.Driver
+    username: sa
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true

--- a/notice-service/src/main/resources/application.yml
+++ b/notice-service/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: notice-service
+  profiles:
+    active: local
 
 eureka:
   instance:

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/notification-service/src/main/java/myaong/popolog/notificationservice/domain/BaseEntity.java
+++ b/notification-service/src/main/java/myaong/popolog/notificationservice/domain/BaseEntity.java
@@ -1,0 +1,27 @@
+package myaong.popolog.notificationservice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+	// 등록일
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	// 수정일
+	@LastModifiedDate
+	@Column(name = "created_at")
+	private LocalDateTime updatedAt;
+}

--- a/notification-service/src/main/java/myaong/popolog/notificationservice/domain/BaseEntity.java
+++ b/notification-service/src/main/java/myaong/popolog/notificationservice/domain/BaseEntity.java
@@ -22,6 +22,6 @@ public abstract class BaseEntity {
 
 	// 수정일
 	@LastModifiedDate
-	@Column(name = "created_at")
+	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 }

--- a/notification-service/src/main/java/myaong/popolog/notificationservice/domain/Notification.java
+++ b/notification-service/src/main/java/myaong/popolog/notificationservice/domain/Notification.java
@@ -1,13 +1,15 @@
 package myaong.popolog.notificationservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`notification`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {
 
 	@Id
@@ -16,22 +18,27 @@ public class Notification extends BaseEntity {
 	private Long id;
 
 	// 대상 회원
-	@Column(name = "member_id", nullable = false)
+	@Column(name = "member_id", nullable = false, updatable = false)
 	private Long memberId;
 
 	// 알림 요약
-	@Column(name = "title", nullable = false)
+	@Column(name = "title", nullable = false, updatable = false)
 	private String title;
 
 	// 상세 내용
-	@Column(name = "content", nullable = false)
+	@Column(name = "content", nullable = false, updatable = false)
 	private String content;
 
 	// 알림 클릭 시 연결 주소
-	@Column(name = "url", nullable = false)
+	@Column(name = "url", nullable = false, updatable = false)
 	private String url;
 
 	// 읽음 여부
 	@Column(name = "is_read", nullable = false)
 	private Boolean isRead;
+
+	@Builder
+	public Notification(Boolean isRead) {
+		this.isRead = isRead;
+	}
 }

--- a/notification-service/src/main/java/myaong/popolog/notificationservice/domain/Notification.java
+++ b/notification-service/src/main/java/myaong/popolog/notificationservice/domain/Notification.java
@@ -1,0 +1,37 @@
+package myaong.popolog.notificationservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`notification`")
+@Getter
+@Setter
+public class Notification extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "noti_id")
+	private Long id;
+
+	// 대상 회원
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	// 알림 요약
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	// 상세 내용
+	@Column(name = "content", nullable = false)
+	private String content;
+
+	// 알림 클릭 시 연결 주소
+	@Column(name = "url", nullable = false)
+	private String url;
+
+	// 읽음 여부
+	@Column(name = "is_read", nullable = false)
+	private Boolean isRead;
+}

--- a/notification-service/src/main/java/myaong/popolog/notificationservice/repository/NotificationRepository.java
+++ b/notification-service/src/main/java/myaong/popolog/notificationservice/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.notificationservice.repository;
+
+import myaong.popolog.notificationservice.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/notification-service/src/main/resources/application-local.yml
+++ b/notification-service/src/main/resources/application-local.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/test
+    driver-class-name: org.h2.Driver
+    username: sa
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: notification-service
+  profiles:
+    active: local
 
 eureka:
   instance:

--- a/portfolio-service/build.gradle
+++ b/portfolio-service/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/domain/BaseEntity.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/domain/BaseEntity.java
@@ -1,0 +1,27 @@
+package myaong.popolog.portfolioservice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+	// 등록일
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	// 수정일
+	@LastModifiedDate
+	@Column(name = "created_at")
+	private LocalDateTime updatedAt;
+}

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/domain/BaseEntity.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/domain/BaseEntity.java
@@ -22,6 +22,6 @@ public abstract class BaseEntity {
 
 	// 수정일
 	@LastModifiedDate
-	@Column(name = "created_at")
+	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 }

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/domain/Portfolio.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/domain/Portfolio.java
@@ -31,7 +31,7 @@ public class Portfolio extends BaseEntity {
 
 	// 관심 직군
 	@Column(name = "pre_job", nullable = false)
-	private String prefferedJob;
+	private String preferredJob;
 
 	// 전체 내용 JSON
 	@Lob

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/domain/Portfolio.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/domain/Portfolio.java
@@ -1,0 +1,44 @@
+package myaong.popolog.portfolioservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`portfolio`")
+@Getter
+@Setter
+public class Portfolio extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "portfolio_id")
+	private Long id;
+
+	// 작성한 회원
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	// 대표 포트폴리오 여부
+	@Column(name = "is_main", nullable = false)
+	private Boolean isMain;
+
+	@Column(name = "memo", nullable = false)
+	private String memo;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	// 관심 직군
+	@Column(name = "pre_job", nullable = false)
+	private String prefferedJob;
+
+	// 전체 내용 JSON
+	@Lob
+	@Column(name = "content", nullable = false)
+	private String content;
+
+	// 공유 키
+	@Column(name = "key", nullable = false)
+	private String key;
+}

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/domain/Portfolio.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/domain/Portfolio.java
@@ -41,7 +41,7 @@ public class Portfolio extends BaseEntity {
 	private String content;
 
 	// 공유 키
-	@Column(name = "key", nullable = false, unique = true, updatable = false)
+	@Column(name = "`key`", nullable = false, unique = true, updatable = false)
 	private String key;
 
 	@Builder

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/domain/Portfolio.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/domain/Portfolio.java
@@ -1,13 +1,15 @@
 package myaong.popolog.portfolioservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`portfolio`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Portfolio extends BaseEntity {
 
 	@Id
@@ -16,7 +18,7 @@ public class Portfolio extends BaseEntity {
 	private Long id;
 
 	// 작성한 회원
-	@Column(name = "member_id", nullable = false)
+	@Column(name = "member_id", nullable = false, updatable = false)
 	private Long memberId;
 
 	// 대표 포트폴리오 여부
@@ -39,6 +41,15 @@ public class Portfolio extends BaseEntity {
 	private String content;
 
 	// 공유 키
-	@Column(name = "key", nullable = false)
+	@Column(name = "key", nullable = false, unique = true, updatable = false)
 	private String key;
+
+	@Builder
+	public Portfolio(Boolean isMain, String memo, String title, String preferredJob, String content) {
+		this.isMain = isMain;
+		this.memo = memo;
+		this.title = title;
+		this.preferredJob = preferredJob;
+		this.content = content;
+	}
 }

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/repository/PortfolioRepository.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/repository/PortfolioRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.portfolioservice.repository;
+
+import myaong.popolog.portfolioservice.domain.Portfolio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
+}

--- a/portfolio-service/src/main/resources/application-local.yml
+++ b/portfolio-service/src/main/resources/application-local.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/test
+    driver-class-name: org.h2.Driver
+    username: sa
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true

--- a/portfolio-service/src/main/resources/application.yml
+++ b/portfolio-service/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: portfolio-service
+  profiles:
+    active: local
 
 eureka:
   instance:

--- a/prejobs-service/build.gradle
+++ b/prejobs-service/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/BaseEntity.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/BaseEntity.java
@@ -22,6 +22,6 @@ public abstract class BaseEntity {
 
 	// 수정일
 	@LastModifiedDate
-	@Column(name = "created_at")
+	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 }

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/BaseEntity.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/BaseEntity.java
@@ -1,0 +1,27 @@
+package myaong.popolog.prejobsservice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+	// 등록일
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	// 수정일
+	@LastModifiedDate
+	@Column(name = "created_at")
+	private LocalDateTime updatedAt;
+}

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/Category.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/Category.java
@@ -1,13 +1,14 @@
 package myaong.popolog.prejobsservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`category`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Category extends BaseEntity {
 
 	@Id
@@ -16,6 +17,6 @@ public class Category extends BaseEntity {
 	private Long id;
 
 	// 카테고리 이름
-	@Column(name = "category_name", nullable = false, unique = true)
+	@Column(name = "category_name", nullable = false, unique = true, updatable = false)
 	private String name;
 }

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/Category.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/Category.java
@@ -16,6 +16,6 @@ public class Category extends BaseEntity {
 	private Long id;
 
 	// 카테고리 이름
-	@Column(name = "category_name", nullable = false)
+	@Column(name = "category_name", nullable = false, unique = true)
 	private String name;
 }

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/Category.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/Category.java
@@ -1,0 +1,21 @@
+package myaong.popolog.prejobsservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`category`")
+@Getter
+@Setter
+public class Category extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "category_id", nullable = false)
+	private Long id;
+
+	// 카테고리 이름
+	@Column(name = "category_name", nullable = false)
+	private String name;
+}

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/Job.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/Job.java
@@ -1,15 +1,17 @@
 package myaong.popolog.prejobsservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`job`",
 		uniqueConstraints = {@UniqueConstraint(columnNames = {"category_id", "job_name"}),
 				@UniqueConstraint(columnNames = {"category_id", "`index`"})})
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Job extends BaseEntity {
 
 	@Id
@@ -19,7 +21,7 @@ public class Job extends BaseEntity {
 
 	// 카테고리
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "category_id", nullable = false)
+	@JoinColumn(name = "category_id", nullable = false, updatable = false)
 	private Category category;
 
 	// 직군 이름
@@ -29,4 +31,10 @@ public class Job extends BaseEntity {
 	// 순서
 	@Column(name = "`index`", nullable = false)
 	private Integer index;
+
+	@Builder
+	public Job(String name, Integer index) {
+		this.name = name;
+		this.index = index;
+	}
 }

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/Job.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/Job.java
@@ -25,6 +25,6 @@ public class Job extends BaseEntity {
 	private String name;
 
 	// 순서
-	@Column(name = "index", nullable = false)
+	@Column(name = "`index`", nullable = false)
 	private Integer index;
 }

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/Job.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/Job.java
@@ -1,0 +1,30 @@
+package myaong.popolog.prejobsservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`job`")
+@Getter
+@Setter
+public class Job extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "job_id")
+	private Long id;
+
+	// 카테고리
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "category_id", nullable = false)
+	private Category category;
+
+	// 직군 이름
+	@Column(name = "job_name", nullable = false)
+	private String name;
+
+	// 순서
+	@Column(name = "index", nullable = false)
+	private Integer index;
+}

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/Job.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/Job.java
@@ -5,7 +5,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Entity
-@Table(name = "`job`")
+@Table(name = "`job`",
+		uniqueConstraints = {@UniqueConstraint(columnNames = {"category_id", "job_name"}),
+				@UniqueConstraint(columnNames = {"category_id", "`index`"})})
 @Getter
 @Setter
 public class Job extends BaseEntity {

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/PreferredJob.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/PreferredJob.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Entity
-@Table(name = "`preferred_job`")
+@Table(name = "`preferred_job`",
+		uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "job_id"})})
 @Getter
 @Setter
 public class PreferredJob extends BaseEntity {

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/PreferredJob.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/PreferredJob.java
@@ -1,0 +1,26 @@
+package myaong.popolog.prejobsservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`preferred_job`")
+@Getter
+@Setter
+public class PreferredJob extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "preferred_job_id")
+	private Long id;
+
+	// 회원 아이디
+	@Column(name = "member_id", nullable = false)
+	private Long member_id;
+
+	// 직군
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "job_id", nullable = false)
+	private Job job;
+}

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/PreferredJob.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/domain/PreferredJob.java
@@ -1,14 +1,15 @@
 package myaong.popolog.prejobsservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`preferred_job`",
 		uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "job_id"})})
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PreferredJob extends BaseEntity {
 
 	@Id
@@ -17,11 +18,11 @@ public class PreferredJob extends BaseEntity {
 	private Long id;
 
 	// 회원 아이디
-	@Column(name = "member_id", nullable = false)
+	@Column(name = "member_id", nullable = false, updatable = false)
 	private Long member_id;
 
 	// 직군
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "job_id", nullable = false)
+	@JoinColumn(name = "job_id", nullable = false, updatable = false)
 	private Job job;
 }

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/repository/CategoryRepository.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.prejobsservice.repository;
+
+import myaong.popolog.prejobsservice.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/repository/JobRepository.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/repository/JobRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.prejobsservice.repository;
+
+import myaong.popolog.prejobsservice.domain.Job;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobRepository extends JpaRepository<Job, Long> {
+}

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/repository/PreferredJobRepository.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/repository/PreferredJobRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.prejobsservice.repository;
+
+import myaong.popolog.prejobsservice.domain.PreferredJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PreferredJobRepository extends JpaRepository<PreferredJob, Long> {
+}

--- a/prejobs-service/src/main/resources/application-local.yml
+++ b/prejobs-service/src/main/resources/application-local.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/test
+    driver-class-name: org.h2.Driver
+    username: sa
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true

--- a/prejobs-service/src/main/resources/application.yml
+++ b/prejobs-service/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: prejobs-service
+  profiles:
+    active: local
 
 eureka:
   instance:

--- a/ps-service/build.gradle
+++ b/ps-service/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/ps-service/src/main/java/myaong/popolog/psservice/domain/BaseEntity.java
+++ b/ps-service/src/main/java/myaong/popolog/psservice/domain/BaseEntity.java
@@ -1,0 +1,27 @@
+package myaong.popolog.psservice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+	// 등록일
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	// 수정일
+	@LastModifiedDate
+	@Column(name = "created_at")
+	private LocalDateTime updatedAt;
+}

--- a/ps-service/src/main/java/myaong/popolog/psservice/domain/BaseEntity.java
+++ b/ps-service/src/main/java/myaong/popolog/psservice/domain/BaseEntity.java
@@ -22,6 +22,6 @@ public abstract class BaseEntity {
 
 	// 수정일
 	@LastModifiedDate
-	@Column(name = "created_at")
+	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 }

--- a/ps-service/src/main/java/myaong/popolog/psservice/domain/Ps.java
+++ b/ps-service/src/main/java/myaong/popolog/psservice/domain/Ps.java
@@ -1,13 +1,15 @@
 package myaong.popolog.psservice.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`ps`")
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Ps extends BaseEntity {
 
 	@Id
@@ -16,7 +18,7 @@ public class Ps extends BaseEntity {
 	private Long id;
 
 	// 작성한 회원
-	@Column(name = "member_id", nullable = false)
+	@Column(name = "member_id", nullable = false, updatable = false)
 	private Long memberId;
 
 	@Column(name = "title", nullable = false)
@@ -35,4 +37,12 @@ public class Ps extends BaseEntity {
 	@Lob
 	@Column(name = "content", nullable = false)
 	private String content;
+
+	@Builder
+	public Ps(String title, String position, String reason, String content) {
+		this.title = title;
+		this.position = position;
+		this.reason = reason;
+		this.content = content;
+	}
 }

--- a/ps-service/src/main/java/myaong/popolog/psservice/domain/Ps.java
+++ b/ps-service/src/main/java/myaong/popolog/psservice/domain/Ps.java
@@ -1,0 +1,38 @@
+package myaong.popolog.psservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "`ps`")
+@Getter
+@Setter
+public class Ps extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "ps_id")
+	private Long id;
+
+	// 작성한 회원
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	// 지원 직무
+	@Column(name = "position", nullable = false)
+	private String position;
+
+	// 지원 사유
+	@Lob
+	@Column(name = "reason", nullable = false)
+	private String reason;
+
+	// 자기소개
+	@Lob
+	@Column(name = "content", nullable = false)
+	private String content;
+}

--- a/ps-service/src/main/java/myaong/popolog/psservice/repository/PsRepository.java
+++ b/ps-service/src/main/java/myaong/popolog/psservice/repository/PsRepository.java
@@ -1,0 +1,7 @@
+package myaong.popolog.psservice.repository;
+
+import myaong.popolog.psservice.domain.Ps;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PsRepository extends JpaRepository<Ps, Long> {
+}

--- a/ps-service/src/main/resources/application-local.yml
+++ b/ps-service/src/main/resources/application-local.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/test
+    driver-class-name: org.h2.Driver
+    username: sa
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true

--- a/ps-service/src/main/resources/application.yml
+++ b/ps-service/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: ps-service
+  profiles:
+    active: local
 
 eureka:
   instance:


### PR DESCRIPTION
1. 협업할 때 DB는 어떻게 써야 하나 찾아보다가 DDL을 따로 쓰지 말라는 결론을 내렸습니다.
제약 조건은 JPA에서 지원해주는 대로 unique, not null만 추가했습니다. 

2. 모든 프로젝트 정상적으로 실행되는 것 개별로 확인했습니다.

3. 다른 서비스에서 관리하는 엔티티의 세부 내용이 필요하여 추가적인 클래스를 만들어 사용하는 서비스는 블로그 서비스(프로필 표시)와 문의 서비스(로그인 아이디 표시)입니다.
블로그 서비스의 member_profile 테이블은 member_id, nickname, profilePic을 가집니다.
문의 서비스의 member_profile 테이블은 member_id, username을 가집니다.
모든 서비스가 하나의 DB를 사용할 경우, 동일한 이름을 가진 테이블이 존재할 수 없기 때문에 둘 중 하나만 남게 되는 것을 확인했습니다.
클라우드 환경에 올릴 땐 개별 DB를 사용하기 때문에 테이블 이름이 같아도 상관 없지만, 아래의 두 가지 이유로 문의 서비스에서 사용할 테이블 이름을 추천 받습니다. 반박 환영합니다.

- 개발 환경에서 DB 분리해서 사용하기 귀찮음
- 문의 서비스에서는 member_**profile**이라는 이름이 적절하지 않은 것 같음