### PR TITLE
⚙️ [chore] #6 - Swagger 설정

### DIFF
--- a/blog-service/build.gradle
+++ b/blog-service/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Swagger(Spring 3.x.x 이상부터 SpringFox 대신, SpringDoc)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/blog-service/src/main/java/myaong/popolog/blogservice/config/SwaggerConfig.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package myaong.popolog.blogservice.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Popolog Blog Service API 명세서")
+                .description("Specification")
+                .version("1.0.0");
+    }
+}

--- a/blog-service/src/main/resources/application.yml
+++ b/blog-service/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 0
+
 spring:
   application:
     name: blog-service

--- a/discovery-service/src/main/resources/application.yml
+++ b/discovery-service/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 8761
+
 spring:
   application:
     name: discovery-service

--- a/inquiry-service/build.gradle
+++ b/inquiry-service/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Swagger(Spring 3.x.x 이상부터 SpringFox 대신, SpringDoc)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/config/SwaggerConfig.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package myaong.popolog.inquiryservice.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Popolog Inquiry Service API 명세서")
+                .description("Specification")
+                .version("1.0.0");
+    }
+}

--- a/inquiry-service/src/main/resources/application.yml
+++ b/inquiry-service/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 0
+
 spring:
   application:
     name: inquiry-service

--- a/interview-service/build.gradle
+++ b/interview-service/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Swagger(Spring 3.x.x 이상부터 SpringFox 대신, SpringDoc)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/config/SwaggerConfig.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package myaong.popolog.interviewservice.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Popolog Member Service API 명세서")
+                .description("Specification")
+                .version("1.0.0");
+    }
+}

--- a/interview-service/src/main/resources/application.yml
+++ b/interview-service/src/main/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     active: local
 
 eureka:
+  instance:
+    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
   client:
     register-with-eureka: true
     fetch-registry: true

--- a/member-service/build.gradle
+++ b/member-service/build.gradle
@@ -29,11 +29,15 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+//    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 //    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Swagger(Spring 3.x.x 이상부터 SpringFox 대신, SpringDoc)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/member-service/src/main/java/myaong/popolog/memberservice/config/SwaggerConfig.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package myaong.popolog.memberservice.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Popolog Member Service API 명세서")
+                .description("Specification")
+                .version("1.0.0");
+    }
+}

--- a/member-service/src/main/resources/application.yml
+++ b/member-service/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 0
+
 spring:
   application:
     name: member-service

--- a/notice-service/build.gradle
+++ b/notice-service/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Swagger(Spring 3.x.x 이상부터 SpringFox 대신, SpringDoc)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/notice-service/src/main/java/myaong/popolog/noticeservice/config/SwaggerConfig.java
+++ b/notice-service/src/main/java/myaong/popolog/noticeservice/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package myaong.popolog.noticeservice.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Popolog Notice Service API 명세서")
+                .description("Specification")
+                .version("1.0.0");
+    }
+}

--- a/notice-service/src/main/resources/application.yml
+++ b/notice-service/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 0
+
 spring:
   application:
     name: notice-service

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Swagger(Spring 3.x.x 이상부터 SpringFox 대신, SpringDoc)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/notification-service/src/main/java/myaong/popolog/notificationservice/config/SwaggerConfig.java
+++ b/notification-service/src/main/java/myaong/popolog/notificationservice/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package myaong.popolog.notificationservice.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Popolog Notification Service API 명세서")
+                .description("Specification")
+                .version("1.0.0");
+    }
+}

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 0
+
 spring:
   application:
     name: notification-service

--- a/portfolio-service/build.gradle
+++ b/portfolio-service/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Swagger(Spring 3.x.x 이상부터 SpringFox 대신, SpringDoc)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/config/SwaggerConfig.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package myaong.popolog.portfolioservice.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Popolog Portfolio Service API 명세서")
+                .description("Specification")
+                .version("1.0.0");
+    }
+}

--- a/portfolio-service/src/main/resources/application.yml
+++ b/portfolio-service/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 0
+
 spring:
   application:
     name: portfolio-service

--- a/prejobs-service/build.gradle
+++ b/prejobs-service/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Swagger(Spring 3.x.x 이상부터 SpringFox 대신, SpringDoc)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/config/SwaggerConfig.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package myaong.popolog.prejobsservice.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Popolog Prejobs Service API 명세서")
+                .description("Specification")
+                .version("1.0.0");
+    }
+}

--- a/prejobs-service/src/main/resources/application.yml
+++ b/prejobs-service/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 0
+
 spring:
   application:
     name: prejobs-service

--- a/ps-service/build.gradle
+++ b/ps-service/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Swagger(Spring 3.x.x 이상부터 SpringFox 대신, SpringDoc)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/ps-service/src/main/java/myaong/popolog/psservice/config/SwaggerConfig.java
+++ b/ps-service/src/main/java/myaong/popolog/psservice/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package myaong.popolog.psservice.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Popolog PS Service API 명세서")
+                .description("Specification")
+                .version("1.0.0");
+    }
+}

--- a/ps-service/src/main/resources/application.yml
+++ b/ps-service/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 0
+
 spring:
   application:
     name: ps-service


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
chore/#6-swagger-setting/KAN-123 -> develop

## 변경 사항
- discovery service, api gateway service 이외의 모든 서비스에 랜덤 포트 적용과 스웨거를 설정했습니다.

## 이슈

## 테스트 결과
<img width="1312" alt="스크린샷 2024-10-14 오후 11 05 31" src="https://github.com/user-attachments/assets/ade34631-652b-42a1-8081-db8473672695">

<img width="465" alt="스크린샷 2024-10-14 오후 11 10 51" src="https://github.com/user-attachments/assets/9d6d697f-5cf1-4906-9db6-540fd90527cc">

1. discovery service를 실행
2. h2 db 실행
3. 이외의 테스트할 service 실행(ex: member service)
4. http://localhost:8761 에 접근해 위의 첫번째 사진의 빨간 박스 부분 클릭
5. 그리고 접속되는 url에서 /actuator/info 를 /swagger-ui/index.html 로 바꿔 입력
혹은 아래와 같이 인텔리제이 실행 로그에서 몇번 포트로 실행되었는지 확인해서 접속하셔도 됩니당

<img width="559" alt="image" src="https://github.com/user-attachments/assets/87d3ca77-72bf-4323-a538-63a82a98e92e">

### 스웨거 화면
<img width="1312" alt="image" src="https://github.com/user-attachments/assets/314753f9-07f9-424d-8504-d1d16bff6d03">

