### PR TITLE
Feature/#5 exception handling/kan 94

### DIFF
--- a/blog-service/src/main/java/myaong/popolog/blogservice/common/exception/ApiCode.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/common/exception/ApiCode.java
@@ -1,0 +1,20 @@
+package myaong.popolog.blogservice.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApiCode {
+
+	OK(HttpStatus.OK, "COMMON_2000", "OK"),
+	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/common/exception/ApiCode.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/common/exception/ApiCode.java
@@ -10,6 +10,7 @@ public enum ApiCode {
 
 	OK(HttpStatus.OK, "COMMON_2000", "OK"),
 	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
+	READ_ONLY_ACCESS(HttpStatus.FORBIDDEN, "COMMON_4031", "You can only read"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
 	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");

--- a/blog-service/src/main/java/myaong/popolog/blogservice/common/exception/ApiCode.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/common/exception/ApiCode.java
@@ -13,7 +13,18 @@ public enum ApiCode {
 	READ_ONLY_ACCESS(HttpStatus.FORBIDDEN, "COMMON_4031", "You can only read"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
-	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error"),
+
+	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_4040", "존재하지 않는 포스트입니다."),
+	UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "POST_4150", "Unsupported Media Type"),
+
+	COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_4040", "존재하지 않는 댓글입니다."),
+
+	MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "MESSAGE_4040", "존재하지 않는 메시지입니다."),
+	MESSAGE_STATE_CONFLICT(HttpStatus.CONFLICT, "MESSAGE_4090", "Message already replied, cannot edit."),
+
+	REPORT_DUPLICATED(HttpStatus.CONFLICT, "REPORT_4090", "이미 신고한 콘텐츠입니다."),
+	;
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/blog-service/src/main/java/myaong/popolog/blogservice/common/exception/ApiException.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/common/exception/ApiException.java
@@ -1,0 +1,19 @@
+package myaong.popolog.blogservice.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+	private final ApiCode apiCode;
+
+	public ApiException(ApiCode apiCode, String message) {
+		super(message);
+		this.apiCode = apiCode;
+	}
+
+	public ApiException(ApiCode apiCode) {
+		super(apiCode.getMessage());
+		this.apiCode = apiCode;
+	}
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/common/exception/ApiResponse.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/common/exception/ApiResponse.java
@@ -1,0 +1,36 @@
+package myaong.popolog.blogservice.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+	private final boolean isSuccess;
+	private final String code;
+	private final String message;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private final T data;
+
+	private ApiResponse(boolean isSuccess, String code, String message, T data) {
+		this.isSuccess = isSuccess;
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+
+	// 성공 응답
+	public static <T> ApiResponse<T> onSuccess(T result) {
+		return new ApiResponse<>(true, ApiCode.OK.getCode(), ApiCode.OK.getMessage(), result);
+	}
+
+	// 실패 응답
+	public static <T> ApiResponse<T> onFailure(ApiCode status) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), null);
+	}
+
+	// 실패 응답인데 errors가 필요한 경우
+	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
+	}
+}

--- a/blog-service/src/main/java/myaong/popolog/blogservice/common/exception/ApiResponse.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/common/exception/ApiResponse.java
@@ -33,4 +33,9 @@ public class ApiResponse<T> {
 	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
 		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
 	}
+
+	// handleExceptionInternal override에서 사용
+	public static <T> ApiResponse<T> onFailure(int code, String message) {
+		return new ApiResponse<>(false, "COMMON_"+code+"0", message, null);
+	}
 }

--- a/blog-service/src/main/java/myaong/popolog/blogservice/common/exception/GlobalExceptionHandler.java
+++ b/blog-service/src/main/java/myaong/popolog/blogservice/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package myaong.popolog.blogservice.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+	// 커스텀 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleCustomException(ApiException ex) {
+		return handleExceptionInternal(ex.getApiCode());
+	}
+
+	// @Valid 검증 예외 처리
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+		List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+
+		List<Map<String, String>> errors = new ArrayList<>();
+		for (FieldError fieldError : fieldErrors) {
+
+			Map<String, String> error = new HashMap<>();
+			error.put("field", fieldError.getField());
+			error.put("message", fieldError.getDefaultMessage());
+
+			errors.add(error);
+		}
+
+		return handleExceptionInternal(ApiCode.INVALID_DATA, errors);
+	}
+
+	// API 인자 불일치 예외 처리
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<Object> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+		return handleExceptionInternal(ApiCode.METHOD_NOT_ALLOWED);
+	}
+
+	// DB 유효성 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleDataIntegrityViolationException(DataIntegrityViolationException e) {
+		return handleExceptionInternal(ApiCode.DB_ERROR);
+	}
+
+	// 그 외 모든 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> handleException(Exception e) {
+		log.error(e.getMessage(), e);
+
+		return handleExceptionInternal(ApiCode.INTERNAL_SERVER_ERROR, e.getMessage());
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode));
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+}

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/common/exception/ApiCode.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/common/exception/ApiCode.java
@@ -1,0 +1,20 @@
+package myaong.popolog.inquiryservice.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApiCode {
+
+	OK(HttpStatus.OK, "COMMON_2000", "OK"),
+	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/common/exception/ApiCode.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/common/exception/ApiCode.java
@@ -12,7 +12,11 @@ public enum ApiCode {
 	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
-	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error"),
+
+	INQUIRY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "INQUIRY", "비공개 문의입니다."),
+	INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY_4040", "존재하지 않는 문의입니다."),
+	;
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/common/exception/ApiException.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/common/exception/ApiException.java
@@ -1,0 +1,19 @@
+package myaong.popolog.inquiryservice.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+	private final ApiCode apiCode;
+
+	public ApiException(ApiCode apiCode, String message) {
+		super(message);
+		this.apiCode = apiCode;
+	}
+
+	public ApiException(ApiCode apiCode) {
+		super(apiCode.getMessage());
+		this.apiCode = apiCode;
+	}
+}

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/common/exception/ApiResponse.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/common/exception/ApiResponse.java
@@ -33,4 +33,9 @@ public class ApiResponse<T> {
 	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
 		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
 	}
+
+	// handleExceptionInternal override에서 사용
+	public static <T> ApiResponse<T> onFailure(int code, String message) {
+		return new ApiResponse<>(false, "COMMON_"+code+"0", message, null);
+	}
 }

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/common/exception/ApiResponse.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/common/exception/ApiResponse.java
@@ -1,0 +1,36 @@
+package myaong.popolog.inquiryservice.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+	private final boolean isSuccess;
+	private final String code;
+	private final String message;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private final T data;
+
+	private ApiResponse(boolean isSuccess, String code, String message, T data) {
+		this.isSuccess = isSuccess;
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+
+	// 성공 응답
+	public static <T> ApiResponse<T> onSuccess(T result) {
+		return new ApiResponse<>(true, ApiCode.OK.getCode(), ApiCode.OK.getMessage(), result);
+	}
+
+	// 실패 응답
+	public static <T> ApiResponse<T> onFailure(ApiCode status) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), null);
+	}
+
+	// 실패 응답인데 errors가 필요한 경우
+	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
+	}
+}

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/common/exception/GlobalExceptionHandler.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package myaong.popolog.inquiryservice.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+	// 커스텀 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleCustomException(ApiException ex) {
+		return handleExceptionInternal(ex.getApiCode());
+	}
+
+	// @Valid 검증 예외 처리
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+		List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+
+		List<Map<String, String>> errors = new ArrayList<>();
+		for (FieldError fieldError : fieldErrors) {
+
+			Map<String, String> error = new HashMap<>();
+			error.put("field", fieldError.getField());
+			error.put("message", fieldError.getDefaultMessage());
+
+			errors.add(error);
+		}
+
+		return handleExceptionInternal(ApiCode.INVALID_DATA, errors);
+	}
+
+	// API 인자 불일치 예외 처리
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<Object> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+		return handleExceptionInternal(ApiCode.METHOD_NOT_ALLOWED);
+	}
+
+	// DB 유효성 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleDataIntegrityViolationException(DataIntegrityViolationException e) {
+		return handleExceptionInternal(ApiCode.DB_ERROR);
+	}
+
+	// 그 외 모든 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> handleException(Exception e) {
+		log.error(e.getMessage(), e);
+
+		return handleExceptionInternal(ApiCode.INTERNAL_SERVER_ERROR, e.getMessage());
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode));
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+}

--- a/inquiry-service/src/main/java/myaong/popolog/inquiryservice/common/exception/GlobalExceptionHandler.java
+++ b/inquiry-service/src/main/java/myaong/popolog/inquiryservice/common/exception/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package myaong.popolog.inquiryservice.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -73,5 +75,22 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
 		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+
+		String message;
+		if (body == null)
+			if (ex instanceof ErrorResponse errorResponse)
+				message = errorResponse.updateAndGetBody(this.getMessageSource(), LocaleContextHolder.getLocale()).getDetail();
+			else
+				message = "Internal server error";
+		else
+			message = ((ErrorResponse) body).getDetailMessageCode();
+
+		body = ApiResponse.onFailure(statusCode.value(), message);
+
+		return ResponseEntity.status(statusCode.value()).body(body);
 	}
 }

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/ApiCode.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/ApiCode.java
@@ -13,7 +13,12 @@ public enum ApiCode {
 	READ_ONLY_ACCESS(HttpStatus.FORBIDDEN, "COMMON_4031", "You can only read"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
-	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error"),
+
+	COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "COMPANY_4040", "면접을 생성할 수 없는 기업입니다."),
+
+	INTERVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "INTERVIEW_4040", "존재하지 않는 면접 기록입니다."),
+	;
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/ApiCode.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/ApiCode.java
@@ -10,6 +10,7 @@ public enum ApiCode {
 
 	OK(HttpStatus.OK, "COMMON_2000", "OK"),
 	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
+	READ_ONLY_ACCESS(HttpStatus.FORBIDDEN, "COMMON_4031", "You can only read"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
 	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/ApiCode.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/ApiCode.java
@@ -1,0 +1,20 @@
+package myaong.popolog.interviewservice.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApiCode {
+
+	OK(HttpStatus.OK, "COMMON_2000", "OK"),
+	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/ApiException.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/ApiException.java
@@ -1,0 +1,19 @@
+package myaong.popolog.interviewservice.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+	private final ApiCode apiCode;
+
+	public ApiException(ApiCode apiCode, String message) {
+		super(message);
+		this.apiCode = apiCode;
+	}
+
+	public ApiException(ApiCode apiCode) {
+		super(apiCode.getMessage());
+		this.apiCode = apiCode;
+	}
+}

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/ApiResponse.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/ApiResponse.java
@@ -1,0 +1,36 @@
+package myaong.popolog.interviewservice.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+	private final boolean isSuccess;
+	private final String code;
+	private final String message;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private final T data;
+
+	private ApiResponse(boolean isSuccess, String code, String message, T data) {
+		this.isSuccess = isSuccess;
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+
+	// 성공 응답
+	public static <T> ApiResponse<T> onSuccess(T result) {
+		return new ApiResponse<>(true, ApiCode.OK.getCode(), ApiCode.OK.getMessage(), result);
+	}
+
+	// 실패 응답
+	public static <T> ApiResponse<T> onFailure(ApiCode status) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), null);
+	}
+
+	// 실패 응답인데 errors가 필요한 경우
+	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
+	}
+}

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/ApiResponse.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/ApiResponse.java
@@ -33,4 +33,9 @@ public class ApiResponse<T> {
 	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
 		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
 	}
+
+	// handleExceptionInternal override에서 사용
+	public static <T> ApiResponse<T> onFailure(int code, String message) {
+		return new ApiResponse<>(false, "COMMON_"+code+"0", message, null);
+	}
 }

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/GlobalExceptionHandler.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package myaong.popolog.interviewservice.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+	// 커스텀 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleCustomException(ApiException ex) {
+		return handleExceptionInternal(ex.getApiCode());
+	}
+
+	// @Valid 검증 예외 처리
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+		List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+
+		List<Map<String, String>> errors = new ArrayList<>();
+		for (FieldError fieldError : fieldErrors) {
+
+			Map<String, String> error = new HashMap<>();
+			error.put("field", fieldError.getField());
+			error.put("message", fieldError.getDefaultMessage());
+
+			errors.add(error);
+		}
+
+		return handleExceptionInternal(ApiCode.INVALID_DATA, errors);
+	}
+
+	// API 인자 불일치 예외 처리
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<Object> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+		return handleExceptionInternal(ApiCode.METHOD_NOT_ALLOWED);
+	}
+
+	// DB 유효성 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleDataIntegrityViolationException(DataIntegrityViolationException e) {
+		return handleExceptionInternal(ApiCode.DB_ERROR);
+	}
+
+	// 그 외 모든 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> handleException(Exception e) {
+		log.error(e.getMessage(), e);
+
+		return handleExceptionInternal(ApiCode.INTERNAL_SERVER_ERROR, e.getMessage());
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode));
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+}

--- a/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/GlobalExceptionHandler.java
+++ b/interview-service/src/main/java/myaong/popolog/interviewservice/common/exception/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package myaong.popolog.interviewservice.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -73,5 +75,22 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
 		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+
+		String message;
+		if (body == null)
+			if (ex instanceof ErrorResponse errorResponse)
+				message = errorResponse.updateAndGetBody(this.getMessageSource(), LocaleContextHolder.getLocale()).getDetail();
+			else
+				message = "Internal server error";
+		else
+			message = ((ErrorResponse) body).getDetailMessageCode();
+
+		body = ApiResponse.onFailure(statusCode.value(), message);
+
+		return ResponseEntity.status(statusCode.value()).body(body);
 	}
 }

--- a/member-service/src/main/java/myaong/popolog/memberservice/common/exception/ApiCode.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/common/exception/ApiCode.java
@@ -10,8 +10,6 @@ public enum ApiCode {
 
 	OK(HttpStatus.OK, "COMMON_2000", "OK"),
 	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
-	TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "COMMON_4010", "Token invalid"),
-	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "COMMON_4011", "Token expired"),
 	FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_4030", "Forbidden"),
 	READ_ONLY_ACCESS(HttpStatus.FORBIDDEN, "COMMON_4031", "You can only read"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),

--- a/member-service/src/main/java/myaong/popolog/memberservice/common/exception/ApiCode.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/common/exception/ApiCode.java
@@ -1,0 +1,24 @@
+package myaong.popolog.memberservice.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApiCode {
+
+	OK(HttpStatus.OK, "COMMON_2000", "OK"),
+	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
+	TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "COMMON_4010", "Token invalid"),
+	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "COMMON_4011", "Token expired"),
+	FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_4030", "Forbidden"),
+	READ_ONLY_ACCESS(HttpStatus.FORBIDDEN, "COMMON_4031", "You can only read"),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/member-service/src/main/java/myaong/popolog/memberservice/common/exception/ApiCode.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/common/exception/ApiCode.java
@@ -11,7 +11,6 @@ public enum ApiCode {
 	OK(HttpStatus.OK, "COMMON_2000", "OK"),
 	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
 	FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_4030", "Forbidden"),
-	READ_ONLY_ACCESS(HttpStatus.FORBIDDEN, "COMMON_4031", "You can only read"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
 	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");

--- a/member-service/src/main/java/myaong/popolog/memberservice/common/exception/ApiCode.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/common/exception/ApiCode.java
@@ -13,7 +13,19 @@ public enum ApiCode {
 	FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_4030", "Forbidden"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
-	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error"),
+
+	RE_AUTHENTICATION_FAILURE(HttpStatus.BAD_REQUEST, "MEMBER_4000", "기존 비밀번호와 일치하지 않습니다."),
+	INCORRECT_ID(HttpStatus.UNAUTHORIZED, "MEMBER_4010", "아이디가 맞지 않습니다. 다시 시도해주세요."),
+	INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "MEMBER_4011", "비밀번호가 맞지 않습니다. 다시 시도해주세요."),	// 재시도 횟수를 함께 전송
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_4040", "존재하지 않는 회원입니다."),
+	ID_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_4041", "가입하지 않은 아이디입니다."),
+	ID_DUPLICATED(HttpStatus.CONFLICT, "MEMBER_4090", "이미 사용된 아이디입니다."),
+	EMAIL_DUPLICATED(HttpStatus.CONFLICT, "MEMBER_4091", "이미 사용된 이메일 주소입니다."),
+	MEMBER_PERMISSION_CONFLICT(HttpStatus.CONFLICT, "MEMBER_4092", "직원이 아닌 회원에게 관리자 권한을 줄 수 없습니다."),
+	ADMIN_PERMISSION_CONFLICT(HttpStatus.CONFLICT, "MEMBER_4093", "관리자 권한이 없는 회원에게 최고 관리자 권한을 줄 수 없습니다."),
+	UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "MEMBER_4150", "Unsupported media type"),
+	;
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/member-service/src/main/java/myaong/popolog/memberservice/common/exception/ApiException.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/common/exception/ApiException.java
@@ -1,0 +1,19 @@
+package myaong.popolog.memberservice.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+	private final ApiCode apiCode;
+
+	public ApiException(ApiCode apiCode, String message) {
+		super(message);
+		this.apiCode = apiCode;
+	}
+
+	public ApiException(ApiCode apiCode) {
+		super(apiCode.getMessage());
+		this.apiCode = apiCode;
+	}
+}

--- a/member-service/src/main/java/myaong/popolog/memberservice/common/exception/ApiResponse.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/common/exception/ApiResponse.java
@@ -1,0 +1,36 @@
+package myaong.popolog.memberservice.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+	private final boolean isSuccess;
+	private final String code;
+	private final String message;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private final T data;
+
+	private ApiResponse(boolean isSuccess, String code, String message, T data) {
+		this.isSuccess = isSuccess;
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+
+	// 성공 응답
+	public static <T> ApiResponse<T> onSuccess(T result) {
+		return new ApiResponse<>(true, ApiCode.OK.getCode(), ApiCode.OK.getMessage(), result);
+	}
+
+	// 실패 응답
+	public static <T> ApiResponse<T> onFailure(ApiCode status) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), null);
+	}
+
+	// 실패 응답인데 errors가 필요한 경우
+	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
+	}
+}

--- a/member-service/src/main/java/myaong/popolog/memberservice/common/exception/ApiResponse.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/common/exception/ApiResponse.java
@@ -33,4 +33,9 @@ public class ApiResponse<T> {
 	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
 		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
 	}
+
+	// handleExceptionInternal override에서 사용
+	public static <T> ApiResponse<T> onFailure(int code, String message) {
+		return new ApiResponse<>(false, "COMMON_"+code+"0", message, null);
+	}
 }

--- a/member-service/src/main/java/myaong/popolog/memberservice/common/exception/GlobalExceptionHandler.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package myaong.popolog.memberservice.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+	// 커스텀 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleCustomException(ApiException ex) {
+		return handleExceptionInternal(ex.getApiCode());
+	}
+
+	// @Valid 검증 예외 처리
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+		List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+
+		List<Map<String, String>> errors = new ArrayList<>();
+		for (FieldError fieldError : fieldErrors) {
+
+			Map<String, String> error = new HashMap<>();
+			error.put("field", fieldError.getField());
+			error.put("message", fieldError.getDefaultMessage());
+
+			errors.add(error);
+		}
+
+		return handleExceptionInternal(ApiCode.INVALID_DATA, errors);
+	}
+
+	// API 인자 불일치 예외 처리
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<Object> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+		return handleExceptionInternal(ApiCode.METHOD_NOT_ALLOWED);
+	}
+
+	// DB 유효성 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleDataIntegrityViolationException(DataIntegrityViolationException e) {
+		return handleExceptionInternal(ApiCode.DB_ERROR);
+	}
+
+	// 그 외 모든 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> handleException(Exception e) {
+		log.error(e.getMessage(), e);
+
+		return handleExceptionInternal(ApiCode.INTERNAL_SERVER_ERROR, e.getMessage());
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode));
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+}

--- a/member-service/src/main/java/myaong/popolog/memberservice/common/exception/GlobalExceptionHandler.java
+++ b/member-service/src/main/java/myaong/popolog/memberservice/common/exception/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package myaong.popolog.memberservice.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -73,5 +75,22 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
 		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+
+		String message;
+		if (body == null)
+			if (ex instanceof ErrorResponse errorResponse)
+				message = errorResponse.updateAndGetBody(this.getMessageSource(), LocaleContextHolder.getLocale()).getDetail();
+			else
+				message = "Internal server error";
+		else
+			message = ((ErrorResponse) body).getDetailMessageCode();
+
+		body = ApiResponse.onFailure(statusCode.value(), message);
+
+		return ResponseEntity.status(statusCode.value()).body(body);
 	}
 }

--- a/notice-service/src/main/java/myaong/popolog/noticeservice/common/exception/ApiCode.java
+++ b/notice-service/src/main/java/myaong/popolog/noticeservice/common/exception/ApiCode.java
@@ -12,7 +12,10 @@ public enum ApiCode {
 	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
-	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error"),
+
+	NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE", "존재하지 않는 공지사항입니다."),
+	;
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/notice-service/src/main/java/myaong/popolog/noticeservice/common/exception/ApiCode.java
+++ b/notice-service/src/main/java/myaong/popolog/noticeservice/common/exception/ApiCode.java
@@ -1,0 +1,20 @@
+package myaong.popolog.noticeservice.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApiCode {
+
+	OK(HttpStatus.OK, "COMMON_2000", "OK"),
+	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/notice-service/src/main/java/myaong/popolog/noticeservice/common/exception/ApiException.java
+++ b/notice-service/src/main/java/myaong/popolog/noticeservice/common/exception/ApiException.java
@@ -1,0 +1,19 @@
+package myaong.popolog.noticeservice.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+	private final ApiCode apiCode;
+
+	public ApiException(ApiCode apiCode, String message) {
+		super(message);
+		this.apiCode = apiCode;
+	}
+
+	public ApiException(ApiCode apiCode) {
+		super(apiCode.getMessage());
+		this.apiCode = apiCode;
+	}
+}

--- a/notice-service/src/main/java/myaong/popolog/noticeservice/common/exception/ApiResponse.java
+++ b/notice-service/src/main/java/myaong/popolog/noticeservice/common/exception/ApiResponse.java
@@ -33,4 +33,9 @@ public class ApiResponse<T> {
 	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
 		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
 	}
+
+	// handleExceptionInternal override에서 사용
+	public static <T> ApiResponse<T> onFailure(int code, String message) {
+		return new ApiResponse<>(false, "COMMON_"+code+"0", message, null);
+	}
 }

--- a/notice-service/src/main/java/myaong/popolog/noticeservice/common/exception/ApiResponse.java
+++ b/notice-service/src/main/java/myaong/popolog/noticeservice/common/exception/ApiResponse.java
@@ -1,0 +1,36 @@
+package myaong.popolog.noticeservice.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+	private final boolean isSuccess;
+	private final String code;
+	private final String message;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private final T data;
+
+	private ApiResponse(boolean isSuccess, String code, String message, T data) {
+		this.isSuccess = isSuccess;
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+
+	// 성공 응답
+	public static <T> ApiResponse<T> onSuccess(T result) {
+		return new ApiResponse<>(true, ApiCode.OK.getCode(), ApiCode.OK.getMessage(), result);
+	}
+
+	// 실패 응답
+	public static <T> ApiResponse<T> onFailure(ApiCode status) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), null);
+	}
+
+	// 실패 응답인데 errors가 필요한 경우
+	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
+	}
+}

--- a/notice-service/src/main/java/myaong/popolog/noticeservice/common/exception/GlobalExceptionHandler.java
+++ b/notice-service/src/main/java/myaong/popolog/noticeservice/common/exception/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package myaong.popolog.noticeservice.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -73,5 +75,22 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
 		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+
+		String message;
+		if (body == null)
+			if (ex instanceof ErrorResponse errorResponse)
+				message = errorResponse.updateAndGetBody(this.getMessageSource(), LocaleContextHolder.getLocale()).getDetail();
+			else
+				message = "Internal server error";
+		else
+			message = ((ErrorResponse) body).getDetailMessageCode();
+
+		body = ApiResponse.onFailure(statusCode.value(), message);
+
+		return ResponseEntity.status(statusCode.value()).body(body);
 	}
 }

--- a/notice-service/src/main/java/myaong/popolog/noticeservice/common/exception/GlobalExceptionHandler.java
+++ b/notice-service/src/main/java/myaong/popolog/noticeservice/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package myaong.popolog.noticeservice.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+	// 커스텀 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleCustomException(ApiException ex) {
+		return handleExceptionInternal(ex.getApiCode());
+	}
+
+	// @Valid 검증 예외 처리
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+		List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+
+		List<Map<String, String>> errors = new ArrayList<>();
+		for (FieldError fieldError : fieldErrors) {
+
+			Map<String, String> error = new HashMap<>();
+			error.put("field", fieldError.getField());
+			error.put("message", fieldError.getDefaultMessage());
+
+			errors.add(error);
+		}
+
+		return handleExceptionInternal(ApiCode.INVALID_DATA, errors);
+	}
+
+	// API 인자 불일치 예외 처리
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<Object> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+		return handleExceptionInternal(ApiCode.METHOD_NOT_ALLOWED);
+	}
+
+	// DB 유효성 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleDataIntegrityViolationException(DataIntegrityViolationException e) {
+		return handleExceptionInternal(ApiCode.DB_ERROR);
+	}
+
+	// 그 외 모든 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> handleException(Exception e) {
+		log.error(e.getMessage(), e);
+
+		return handleExceptionInternal(ApiCode.INTERNAL_SERVER_ERROR, e.getMessage());
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode));
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+}

--- a/notification-service/src/main/java/myaong/popolog/notificationservice/common/exception/ApiCode.java
+++ b/notification-service/src/main/java/myaong/popolog/notificationservice/common/exception/ApiCode.java
@@ -1,0 +1,20 @@
+package myaong.popolog.notificationservice.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApiCode {
+
+	OK(HttpStatus.OK, "COMMON_2000", "OK"),
+	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/notification-service/src/main/java/myaong/popolog/notificationservice/common/exception/ApiException.java
+++ b/notification-service/src/main/java/myaong/popolog/notificationservice/common/exception/ApiException.java
@@ -1,0 +1,19 @@
+package myaong.popolog.notificationservice.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+	private final ApiCode apiCode;
+
+	public ApiException(ApiCode apiCode, String message) {
+		super(message);
+		this.apiCode = apiCode;
+	}
+
+	public ApiException(ApiCode apiCode) {
+		super(apiCode.getMessage());
+		this.apiCode = apiCode;
+	}
+}

--- a/notification-service/src/main/java/myaong/popolog/notificationservice/common/exception/ApiResponse.java
+++ b/notification-service/src/main/java/myaong/popolog/notificationservice/common/exception/ApiResponse.java
@@ -33,4 +33,9 @@ public class ApiResponse<T> {
 	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
 		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
 	}
+
+	// handleExceptionInternal override에서 사용
+	public static <T> ApiResponse<T> onFailure(int code, String message) {
+		return new ApiResponse<>(false, "COMMON_"+code+"0", message, null);
+	}
 }

--- a/notification-service/src/main/java/myaong/popolog/notificationservice/common/exception/ApiResponse.java
+++ b/notification-service/src/main/java/myaong/popolog/notificationservice/common/exception/ApiResponse.java
@@ -1,0 +1,36 @@
+package myaong.popolog.notificationservice.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+	private final boolean isSuccess;
+	private final String code;
+	private final String message;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private final T data;
+
+	private ApiResponse(boolean isSuccess, String code, String message, T data) {
+		this.isSuccess = isSuccess;
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+
+	// 성공 응답
+	public static <T> ApiResponse<T> onSuccess(T result) {
+		return new ApiResponse<>(true, ApiCode.OK.getCode(), ApiCode.OK.getMessage(), result);
+	}
+
+	// 실패 응답
+	public static <T> ApiResponse<T> onFailure(ApiCode status) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), null);
+	}
+
+	// 실패 응답인데 errors가 필요한 경우
+	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
+	}
+}

--- a/notification-service/src/main/java/myaong/popolog/notificationservice/common/exception/GlobalExceptionHandler.java
+++ b/notification-service/src/main/java/myaong/popolog/notificationservice/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package myaong.popolog.notificationservice.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+	// 커스텀 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleCustomException(ApiException ex) {
+		return handleExceptionInternal(ex.getApiCode());
+	}
+
+	// @Valid 검증 예외 처리
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+		List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+
+		List<Map<String, String>> errors = new ArrayList<>();
+		for (FieldError fieldError : fieldErrors) {
+
+			Map<String, String> error = new HashMap<>();
+			error.put("field", fieldError.getField());
+			error.put("message", fieldError.getDefaultMessage());
+
+			errors.add(error);
+		}
+
+		return handleExceptionInternal(ApiCode.INVALID_DATA, errors);
+	}
+
+	// API 인자 불일치 예외 처리
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<Object> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+		return handleExceptionInternal(ApiCode.METHOD_NOT_ALLOWED);
+	}
+
+	// DB 유효성 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleDataIntegrityViolationException(DataIntegrityViolationException e) {
+		return handleExceptionInternal(ApiCode.DB_ERROR);
+	}
+
+	// 그 외 모든 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> handleException(Exception e) {
+		log.error(e.getMessage(), e);
+
+		return handleExceptionInternal(ApiCode.INTERNAL_SERVER_ERROR, e.getMessage());
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode));
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+}

--- a/notification-service/src/main/java/myaong/popolog/notificationservice/common/exception/GlobalExceptionHandler.java
+++ b/notification-service/src/main/java/myaong/popolog/notificationservice/common/exception/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package myaong.popolog.notificationservice.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -73,5 +75,22 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
 		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+
+		String message;
+		if (body == null)
+			if (ex instanceof ErrorResponse errorResponse)
+				message = errorResponse.updateAndGetBody(this.getMessageSource(), LocaleContextHolder.getLocale()).getDetail();
+			else
+				message = "Internal server error";
+		else
+			message = ((ErrorResponse) body).getDetailMessageCode();
+
+		body = ApiResponse.onFailure(statusCode.value(), message);
+
+		return ResponseEntity.status(statusCode.value()).body(body);
 	}
 }

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/ApiCode.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/ApiCode.java
@@ -10,6 +10,7 @@ public enum ApiCode {
 
 	OK(HttpStatus.OK, "COMMON_2000", "OK"),
 	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
+	READ_ONLY_ACCESS(HttpStatus.FORBIDDEN, "COMMON_4031", "You can only read"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
 	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/ApiCode.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/ApiCode.java
@@ -1,0 +1,20 @@
+package myaong.popolog.portfolioservice.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApiCode {
+
+	OK(HttpStatus.OK, "COMMON_2000", "OK"),
+	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/ApiCode.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/ApiCode.java
@@ -13,7 +13,12 @@ public enum ApiCode {
 	READ_ONLY_ACCESS(HttpStatus.FORBIDDEN, "COMMON_4031", "You can only read"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
-	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error"),
+
+	KEY_INVALID(HttpStatus.FORBIDDEN, "PORT_4030", " 잘못된 키입니다. URL을 다시 확인해주세요."),
+	PORTFOLIO_NOT_FOUND(HttpStatus.NOT_FOUND, "PORT_4040", "존재하지 않는 포트폴리오입니다."),
+	PORTFOLIO_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "PORT_4090", "You cannot add more then 5 portfolios."),
+	;
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/ApiException.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/ApiException.java
@@ -1,0 +1,19 @@
+package myaong.popolog.portfolioservice.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+	private final ApiCode apiCode;
+
+	public ApiException(ApiCode apiCode, String message) {
+		super(message);
+		this.apiCode = apiCode;
+	}
+
+	public ApiException(ApiCode apiCode) {
+		super(apiCode.getMessage());
+		this.apiCode = apiCode;
+	}
+}

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/ApiResponse.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/ApiResponse.java
@@ -1,0 +1,36 @@
+package myaong.popolog.portfolioservice.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+	private final boolean isSuccess;
+	private final String code;
+	private final String message;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private final T data;
+
+	private ApiResponse(boolean isSuccess, String code, String message, T data) {
+		this.isSuccess = isSuccess;
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+
+	// 성공 응답
+	public static <T> ApiResponse<T> onSuccess(T result) {
+		return new ApiResponse<>(true, ApiCode.OK.getCode(), ApiCode.OK.getMessage(), result);
+	}
+
+	// 실패 응답
+	public static <T> ApiResponse<T> onFailure(ApiCode status) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), null);
+	}
+
+	// 실패 응답인데 errors가 필요한 경우
+	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
+	}
+}

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/ApiResponse.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/ApiResponse.java
@@ -33,4 +33,9 @@ public class ApiResponse<T> {
 	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
 		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
 	}
+
+	// handleExceptionInternal override에서 사용
+	public static <T> ApiResponse<T> onFailure(int code, String message) {
+		return new ApiResponse<>(false, "COMMON_"+code+"0", message, null);
+	}
 }

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/GlobalExceptionHandler.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package myaong.popolog.portfolioservice.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+	// 커스텀 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleCustomException(ApiException ex) {
+		return handleExceptionInternal(ex.getApiCode());
+	}
+
+	// @Valid 검증 예외 처리
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+		List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+
+		List<Map<String, String>> errors = new ArrayList<>();
+		for (FieldError fieldError : fieldErrors) {
+
+			Map<String, String> error = new HashMap<>();
+			error.put("field", fieldError.getField());
+			error.put("message", fieldError.getDefaultMessage());
+
+			errors.add(error);
+		}
+
+		return handleExceptionInternal(ApiCode.INVALID_DATA, errors);
+	}
+
+	// API 인자 불일치 예외 처리
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<Object> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+		return handleExceptionInternal(ApiCode.METHOD_NOT_ALLOWED);
+	}
+
+	// DB 유효성 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleDataIntegrityViolationException(DataIntegrityViolationException e) {
+		return handleExceptionInternal(ApiCode.DB_ERROR);
+	}
+
+	// 그 외 모든 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> handleException(Exception e) {
+		log.error(e.getMessage(), e);
+
+		return handleExceptionInternal(ApiCode.INTERNAL_SERVER_ERROR, e.getMessage());
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode));
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+}

--- a/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/GlobalExceptionHandler.java
+++ b/portfolio-service/src/main/java/myaong/popolog/portfolioservice/common/exception/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package myaong.popolog.portfolioservice.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -73,5 +75,22 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
 		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+
+		String message;
+		if (body == null)
+			if (ex instanceof ErrorResponse errorResponse)
+				message = errorResponse.updateAndGetBody(this.getMessageSource(), LocaleContextHolder.getLocale()).getDetail();
+			else
+				message = "Internal server error";
+		else
+			message = ((ErrorResponse) body).getDetailMessageCode();
+
+		body = ApiResponse.onFailure(statusCode.value(), message);
+
+		return ResponseEntity.status(statusCode.value()).body(body);
 	}
 }

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/common/exception/ApiCode.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/common/exception/ApiCode.java
@@ -1,0 +1,20 @@
+package myaong.popolog.prejobsservice.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApiCode {
+
+	OK(HttpStatus.OK, "COMMON_2000", "OK"),
+	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/common/exception/ApiCode.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/common/exception/ApiCode.java
@@ -12,7 +12,13 @@ public enum ApiCode {
 	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
-	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error"),
+
+	CATEGORY_DUPLICATED(HttpStatus.CONFLICT, "JOB_4090", "이미 존재하는 카테고리 이름입니다."),
+	CATEGORY_CONFLICT(HttpStatus.CONFLICT, "JOB_4091", "해당 카테고리에 속하는 직군이 있어 삭제할 수 없습니다."),
+	JOB_DUPLICATED(HttpStatus.CONFLICT, "JOB_4092", "해당 카테고리 내에 이미 존재하는 직군 이름입니다."),
+	JOB_CONFLICT(HttpStatus.CONFLICT, "JOB_4093", "해당 직군을 선택한 회원이 있어 삭제할 수 없습니다."),
+	;
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/common/exception/ApiException.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/common/exception/ApiException.java
@@ -1,0 +1,19 @@
+package myaong.popolog.prejobsservice.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+	private final ApiCode apiCode;
+
+	public ApiException(ApiCode apiCode, String message) {
+		super(message);
+		this.apiCode = apiCode;
+	}
+
+	public ApiException(ApiCode apiCode) {
+		super(apiCode.getMessage());
+		this.apiCode = apiCode;
+	}
+}

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/common/exception/ApiResponse.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/common/exception/ApiResponse.java
@@ -33,4 +33,9 @@ public class ApiResponse<T> {
 	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
 		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
 	}
+
+	// handleExceptionInternal override에서 사용
+	public static <T> ApiResponse<T> onFailure(int code, String message) {
+		return new ApiResponse<>(false, "COMMON_"+code+"0", message, null);
+	}
 }

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/common/exception/ApiResponse.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/common/exception/ApiResponse.java
@@ -1,0 +1,36 @@
+package myaong.popolog.prejobsservice.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+	private final boolean isSuccess;
+	private final String code;
+	private final String message;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private final T data;
+
+	private ApiResponse(boolean isSuccess, String code, String message, T data) {
+		this.isSuccess = isSuccess;
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+
+	// 성공 응답
+	public static <T> ApiResponse<T> onSuccess(T result) {
+		return new ApiResponse<>(true, ApiCode.OK.getCode(), ApiCode.OK.getMessage(), result);
+	}
+
+	// 실패 응답
+	public static <T> ApiResponse<T> onFailure(ApiCode status) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), null);
+	}
+
+	// 실패 응답인데 errors가 필요한 경우
+	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
+	}
+}

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/common/exception/GlobalExceptionHandler.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package myaong.popolog.prejobsservice.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+	// 커스텀 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleCustomException(ApiException ex) {
+		return handleExceptionInternal(ex.getApiCode());
+	}
+
+	// @Valid 검증 예외 처리
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+		List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+
+		List<Map<String, String>> errors = new ArrayList<>();
+		for (FieldError fieldError : fieldErrors) {
+
+			Map<String, String> error = new HashMap<>();
+			error.put("field", fieldError.getField());
+			error.put("message", fieldError.getDefaultMessage());
+
+			errors.add(error);
+		}
+
+		return handleExceptionInternal(ApiCode.INVALID_DATA, errors);
+	}
+
+	// API 인자 불일치 예외 처리
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<Object> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+		return handleExceptionInternal(ApiCode.METHOD_NOT_ALLOWED);
+	}
+
+	// DB 유효성 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleDataIntegrityViolationException(DataIntegrityViolationException e) {
+		return handleExceptionInternal(ApiCode.DB_ERROR);
+	}
+
+	// 그 외 모든 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> handleException(Exception e) {
+		log.error(e.getMessage(), e);
+
+		return handleExceptionInternal(ApiCode.INTERNAL_SERVER_ERROR, e.getMessage());
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode));
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+}

--- a/prejobs-service/src/main/java/myaong/popolog/prejobsservice/common/exception/GlobalExceptionHandler.java
+++ b/prejobs-service/src/main/java/myaong/popolog/prejobsservice/common/exception/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package myaong.popolog.prejobsservice.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -73,5 +75,22 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
 		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+
+		String message;
+		if (body == null)
+			if (ex instanceof ErrorResponse errorResponse)
+				message = errorResponse.updateAndGetBody(this.getMessageSource(), LocaleContextHolder.getLocale()).getDetail();
+			else
+				message = "Internal server error";
+		else
+			message = ((ErrorResponse) body).getDetailMessageCode();
+
+		body = ApiResponse.onFailure(statusCode.value(), message);
+
+		return ResponseEntity.status(statusCode.value()).body(body);
 	}
 }

--- a/ps-service/src/main/java/myaong/popolog/psservice/common/exception/ApiCode.java
+++ b/ps-service/src/main/java/myaong/popolog/psservice/common/exception/ApiCode.java
@@ -10,6 +10,7 @@ public enum ApiCode {
 
 	OK(HttpStatus.OK, "COMMON_2000", "OK"),
 	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
+	READ_ONLY_ACCESS(HttpStatus.FORBIDDEN, "COMMON_4031", "You can only read"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
 	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");

--- a/ps-service/src/main/java/myaong/popolog/psservice/common/exception/ApiCode.java
+++ b/ps-service/src/main/java/myaong/popolog/psservice/common/exception/ApiCode.java
@@ -1,0 +1,20 @@
+package myaong.popolog.psservice.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApiCode {
+
+	OK(HttpStatus.OK, "COMMON_2000", "OK"),
+	INVALID_DATA(HttpStatus.BAD_REQUEST, "COMMON_4000", "Request data missing or invalid"),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/ps-service/src/main/java/myaong/popolog/psservice/common/exception/ApiCode.java
+++ b/ps-service/src/main/java/myaong/popolog/psservice/common/exception/ApiCode.java
@@ -13,7 +13,10 @@ public enum ApiCode {
 	READ_ONLY_ACCESS(HttpStatus.FORBIDDEN, "COMMON_4031", "You can only read"),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_4050", "Method not allowed"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5000", "Internal Server Error"),
-	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error");
+	DB_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_5001", "DB Error"),
+
+	PS_NOT_FOUND(HttpStatus.NOT_FOUND, "PS_4040", "존재하지 않는 자기소개서입니다."),
+	;
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/ps-service/src/main/java/myaong/popolog/psservice/common/exception/ApiException.java
+++ b/ps-service/src/main/java/myaong/popolog/psservice/common/exception/ApiException.java
@@ -1,0 +1,19 @@
+package myaong.popolog.psservice.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+	private final ApiCode apiCode;
+
+	public ApiException(ApiCode apiCode, String message) {
+		super(message);
+		this.apiCode = apiCode;
+	}
+
+	public ApiException(ApiCode apiCode) {
+		super(apiCode.getMessage());
+		this.apiCode = apiCode;
+	}
+}

--- a/ps-service/src/main/java/myaong/popolog/psservice/common/exception/ApiResponse.java
+++ b/ps-service/src/main/java/myaong/popolog/psservice/common/exception/ApiResponse.java
@@ -33,4 +33,9 @@ public class ApiResponse<T> {
 	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
 		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
 	}
+
+	// handleExceptionInternal override에서 사용
+	public static <T> ApiResponse<T> onFailure(int code, String message) {
+		return new ApiResponse<>(false, "COMMON_"+code+"0", message, null);
+	}
 }

--- a/ps-service/src/main/java/myaong/popolog/psservice/common/exception/ApiResponse.java
+++ b/ps-service/src/main/java/myaong/popolog/psservice/common/exception/ApiResponse.java
@@ -1,0 +1,36 @@
+package myaong.popolog.psservice.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+	private final boolean isSuccess;
+	private final String code;
+	private final String message;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private final T data;
+
+	private ApiResponse(boolean isSuccess, String code, String message, T data) {
+		this.isSuccess = isSuccess;
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+
+	// 성공 응답
+	public static <T> ApiResponse<T> onSuccess(T result) {
+		return new ApiResponse<>(true, ApiCode.OK.getCode(), ApiCode.OK.getMessage(), result);
+	}
+
+	// 실패 응답
+	public static <T> ApiResponse<T> onFailure(ApiCode status) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), null);
+	}
+
+	// 실패 응답인데 errors가 필요한 경우
+	public static <T> ApiResponse<T> onFailure(ApiCode status, T errors) {
+		return new ApiResponse<>(false, status.getCode(), status.getMessage(), errors);
+	}
+}

--- a/ps-service/src/main/java/myaong/popolog/psservice/common/exception/GlobalExceptionHandler.java
+++ b/ps-service/src/main/java/myaong/popolog/psservice/common/exception/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package myaong.popolog.psservice.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -73,5 +75,22 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
 		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+
+		String message;
+		if (body == null)
+			if (ex instanceof ErrorResponse errorResponse)
+				message = errorResponse.updateAndGetBody(this.getMessageSource(), LocaleContextHolder.getLocale()).getDetail();
+			else
+				message = "Internal server error";
+		else
+			message = ((ErrorResponse) body).getDetailMessageCode();
+
+		body = ApiResponse.onFailure(statusCode.value(), message);
+
+		return ResponseEntity.status(statusCode.value()).body(body);
 	}
 }

--- a/ps-service/src/main/java/myaong/popolog/psservice/common/exception/GlobalExceptionHandler.java
+++ b/ps-service/src/main/java/myaong/popolog/psservice/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package myaong.popolog.psservice.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+	// 커스텀 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleCustomException(ApiException ex) {
+		return handleExceptionInternal(ex.getApiCode());
+	}
+
+	// @Valid 검증 예외 처리
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+		List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+
+		List<Map<String, String>> errors = new ArrayList<>();
+		for (FieldError fieldError : fieldErrors) {
+
+			Map<String, String> error = new HashMap<>();
+			error.put("field", fieldError.getField());
+			error.put("message", fieldError.getDefaultMessage());
+
+			errors.add(error);
+		}
+
+		return handleExceptionInternal(ApiCode.INVALID_DATA, errors);
+	}
+
+	// API 인자 불일치 예외 처리
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<Object> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+		return handleExceptionInternal(ApiCode.METHOD_NOT_ALLOWED);
+	}
+
+	// DB 유효성 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> HandleDataIntegrityViolationException(DataIntegrityViolationException e) {
+		return handleExceptionInternal(ApiCode.DB_ERROR);
+	}
+
+	// 그 외 모든 예외 처리
+	@ExceptionHandler
+	public ResponseEntity<Object> handleException(Exception e) {
+		log.error(e.getMessage(), e);
+
+		return handleExceptionInternal(ApiCode.INTERNAL_SERVER_ERROR, e.getMessage());
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode));
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal (ApiCode apiCode, Object errors) {
+		return ResponseEntity.status(apiCode.getHttpStatus()).body(ApiResponse.onFailure(apiCode, errors));
+	}
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
develop

## 변경 사항
API 응답 구조 및 상태 코드 Enum을 작성했습니다.
서비스 전반에 보편적으로 발생할 수 있는 예외를 처리하기 위한 핸들러를 작성했습니다.

## 이슈
- #5 

## 테스트 결과
1. 커스텀 예외 처리에 대해 테스트 컨트롤러를 생성하여 테스트했습니다.
![image](https://github.com/user-attachments/assets/98bd6dfd-8108-410b-bf39-eab5a6c881df)
a.
![image](https://github.com/user-attachments/assets/9dd38208-5593-4cb4-8989-9753f1f2e20f)
b
![image](https://github.com/user-attachments/assets/e1bcabad-b289-49ee-b838-eb09efe74273)

3. ResponseEntityExceptionHandler에 정의된 예외 처리에 대해 아무 URL을 넣어 테스트했습니다.
![image](https://github.com/user-attachments/assets/7e7afc2d-6103-4c5f-9549-4b46a1ca491d)

4. ResponseEntityExceptionHandler에 정의된 예외 처리에 대해 잘못된 method를 넣어 테스트했습니다.
![image](https://github.com/user-attachments/assets/8aad04b2-2aa0-49da-903f-aaf814f584dc)